### PR TITLE
Sync README badges with flywheel

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -1,0 +1,13 @@
+name: Lint & Format
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: |
+          pip install black
+          black --check .

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: |
+          pip install -e .
+          pip install pytest pytest-cov
+          pytest --cov=gitshelves --cov-report=xml --cov-report=term -q
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: true

--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -1,0 +1,17 @@
+name: Docs
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: |
+          pip install linkchecker
+          linkchecker README.md || true

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Gitshelves
 
+[![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/gitshelves/.github/workflows/01-lint-format.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/gitshelves/actions/workflows/01-lint-format.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/gitshelves/.github/workflows/02-tests.yml?label=tests)](https://github.com/futuroptimist/gitshelves/actions/workflows/02-tests.yml)
+[![Coverage](https://codecov.io/gh/futuroptimist/gitshelves/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/gitshelves)
+[![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/gitshelves/.github/workflows/03-docs.yml?label=docs)](https://github.com/futuroptimist/gitshelves/actions/workflows/03-docs.yml)
+[![License](https://img.shields.io/github/license/futuroptimist/gitshelves)](LICENSE)
+
 Gitshelves fetches GitHub contribution data and turns it into 3D printable models. Each month of activity becomes a stack of blocks whose height is determined logarithmically by the number of contributions. The models are exported as `.scad` files for OpenSCAD and can be previewed with Three.js.
 
-## Getting Started
+## Usage
 
-Install the package in editable mode and run the CLI to generate a `.scad` file:
+1. Install the package in editable mode.
+2. Run the CLI to generate a `.scad` file.
 
 ```bash
 pip install -e .
@@ -12,10 +19,6 @@ python -m gitshelves.cli <github-username> --token <gh-token> \
     --start-year 2021 --end-year 2023
 ```
 
-The command will create `contributions.scad` in the current directory.
+The command will create `contributions.scad` in the current directory. Months are arranged in a 1x12 grid for each year so multiple years fit on a single platform.
 
-The resulting model arranges months in a 1x12 grid for each year, stacked
-side-by-side so multiple years fit on a single platform.
-
-See [AGENTS.md](AGENTS.md) for agent workflow guidelines.
-
+See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs under [docs/](docs/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Gitshelves Docs
+
+More documentation coming soon.


### PR DESCRIPTION
## Summary
- add CI and docs workflows
- show lint, test, coverage, docs and license badges in README
- create placeholder docs directory

## Testing
- `pip install -e .`
- `pytest -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6879f1f332b4832fbc057ce5c1fa22bf