### PR TITLE
Fix gridfinity library for STL build

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -15,6 +15,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Fetch Gridfinity library
+      run: |
+        git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad \
+          openscad/lib/gridfinity-rebuilt
     - name: Install OpenSCAD
       run: sudo apt-get update && sudo apt-get install -y openscad
     - name: Build STL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@
 - `gitshelves/` Python package with CLI modules
 - `tests/` pytest suite
 - `docs/` additional documentation
-- `.github/workflows/build-stl.yml` installs OpenSCAD via `apt` and renders STL files from SCAD sources
-- `openscad/lib/gridfinity-rebuilt/` placeholder for Gridfinity library (clone manually)
+- `.github/workflows/build-stl.yml` clones the Gridfinity library, installs OpenSCAD via `apt`, and renders STL files from SCAD sources
+- `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library. CI clones it automatically; clone it manually for local builds
 
 ## Coding Conventions
 - Python code is formatted with `black`
@@ -28,4 +28,4 @@ pytest -q
    ```
 2. Update `README.md` and `AGENTS.md` when CLI options or workflows change.
 3. Include a clear description and reference relevant issues.
-4. Clone the Gridfinity library into `openscad/lib/gridfinity-rebuilt` if it's missing.
+4. For local testing, clone `gridfinity-rebuilt-openscad` into `openscad/lib/gridfinity-rebuilt` if it's not already present.

--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs und
 
 ## Dependencies
 
- - [Gridfinity-Rebuilt-OpenSCAD](https://github.com/kennetek/gridfinity-rebuilt-openscad) – parametric Gridfinity modules. **TODO:** add as a submodule in `openscad/lib/gridfinity-rebuilt`.
+ - [Gridfinity-Rebuilt-OpenSCAD](https://github.com/kennetek/gridfinity-rebuilt-openscad) – parametric Gridfinity modules. The CI workflow clones this repo into `openscad/lib/gridfinity-rebuilt` when building STL files.
 - [OpenSCAD](https://openscad.org/) ≥ 2024.06 – required to render STL files.
 - GitHub Actions installs `openscad` via `apt` to convert `.scad` sources to binary STL outputs.
 
 ## How to Build Locally
 
 ```bash
+# Clone the Gridfinity library locally (the CI workflow does this automatically)
 git clone https://github.com/kennetek/gridfinity-rebuilt-openscad \
     openscad/lib/gridfinity-rebuilt
 openscad -o stl/2024/baseplate_1x12.stl openscad/baseplate_1x12.scad


### PR DESCRIPTION
## Summary
- automatically clone Gridfinity library in build-stl workflow
- document Gridfinity library cloning in README and AGENTS guide

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688880f3990c832fa18d2d6e8ddb4812