### PR TITLE
Fix Gridfinity repo clone path

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -15,10 +15,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Prepare library folder
+      run: mkdir -p openscad/lib
     - name: Fetch Gridfinity library
-      run: |
-        git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad \
-          openscad/lib/gridfinity-rebuilt
+      run: git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad openscad/lib/gridfinity-rebuilt
     - name: Install OpenSCAD
       run: sudo apt-get update && sudo apt-get install -y openscad
     - name: Build STL


### PR DESCRIPTION
## Summary
- prep Gridfinity library directory before cloning
- simplify clone command in CI workflow

## Testing
- `black --check .`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888864afce8832fbad20041ae6053df