### PR TITLE
Fix gridfinity clone path for CI

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -16,9 +16,10 @@ jobs:
       with:
         submodules: recursive
     - name: Prepare library folder
-      run: mkdir -p openscad/lib
-    - name: Fetch Gridfinity library
-      run: git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad openscad/lib/gridfinity-rebuilt
+      run: |
+        rm -rf openscad/lib/gridfinity-rebuilt
+        mkdir -p openscad/lib
+        git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad openscad/lib/gridfinity-rebuilt
     - name: Install OpenSCAD
       run: sudo apt-get update && sudo apt-get install -y openscad
     - name: Build STL


### PR DESCRIPTION
## Summary
- remove any preexisting Gridfinity submodule directory before cloning

## Testing
- `black --check .`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888872e0cfc832f87a73ee01bf4306e