### PR TITLE
Fix CI library cloning error

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Prepare library folder
       run: mkdir -p openscad/lib
     - name: Fetch Gridfinity library
-      run: git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad openscad/lib/gridfinity-rebuilt
+      run: |
+        rm -rf openscad/lib/gridfinity-rebuilt
+        git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad openscad/lib/gridfinity-rebuilt
     - name: Install OpenSCAD
       run: sudo apt-get update && sudo apt-get install -y openscad
     - name: Build STL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - `gitshelves/` Python package with CLI modules
 - `tests/` pytest suite
 - `docs/` additional documentation
-- `.github/workflows/build-stl.yml` clones the Gridfinity library, installs OpenSCAD via `apt`, and renders STL files from SCAD sources
+- `.github/workflows/build-stl.yml` removes any existing Gridfinity library folder, clones the library, installs OpenSCAD via `apt`, and renders STL files from SCAD sources
 - `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library. CI clones it automatically; clone it manually for local builds
 
 ## Coding Conventions


### PR DESCRIPTION
## Summary
- delete existing gridfinity library folder before cloning
- document the workflow step in `AGENTS.md`

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888872e0cfc832f87a73ee01bf4306e