### PR TITLE
Fix headless STL workflow

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -21,13 +21,16 @@ jobs:
       run: |
         rm -rf openscad/lib/gridfinity-rebuilt
         git clone --depth 1 https://github.com/kennetek/gridfinity-rebuilt-openscad openscad/lib/gridfinity-rebuilt
-    - name: Install OpenSCAD
-      run: sudo apt-get update && sudo apt-get install -y openscad
+    - name: Install OpenSCAD + Xvfb
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends openscad xvfb
     - name: Build STL
       run: |
         mkdir -p stl/${{ matrix.year }}
-        openscad -o stl/${{ matrix.year }}/baseplate_1x12.stl \
-          openscad/baseplate_1x12.scad --export-format binstl
+        xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" \
+          openscad -o stl/${{ matrix.year }}/baseplate_1x12.stl \
+            openscad/baseplate_1x12.scad --export-format binstl
     - name: Upload STL
       uses: actions/upload-artifact@v4
       with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - `gitshelves/` Python package with CLI modules
 - `tests/` pytest suite
 - `docs/` additional documentation
-- `.github/workflows/build-stl.yml` removes any existing Gridfinity library folder, clones the library, installs OpenSCAD via `apt`, renders STL files from SCAD sources, and uploads them as workflow artifacts
+- `.github/workflows/build-stl.yml` removes any existing Gridfinity library folder, clones the library, installs OpenSCAD and Xvfb via `apt`, renders STL files from SCAD sources using `xvfb-run`, and uploads them as workflow artifacts
 - `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library. CI clones it automatically; clone it manually for local builds
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs und
 
  - [Gridfinity-Rebuilt-OpenSCAD](https://github.com/kennetek/gridfinity-rebuilt-openscad) – parametric Gridfinity modules. The CI workflow clones this repo into `openscad/lib/gridfinity-rebuilt` when building STL files.
 - [OpenSCAD](https://openscad.org/) ≥ 2024.06 – required to render STL files.
-- GitHub Actions installs `openscad` via `apt` to convert `.scad` sources to binary STL outputs.
+- GitHub Actions installs `openscad` with `xvfb` to convert `.scad` sources to binary STL outputs in a headless environment.
 
 ## How to Build Locally
 
@@ -49,6 +49,7 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs und
 # Clone the Gridfinity library locally (the CI workflow does this automatically)
 git clone https://github.com/kennetek/gridfinity-rebuilt-openscad \
     openscad/lib/gridfinity-rebuilt
+# Wrap with `xvfb-run` if running on a headless server
 openscad -o stl/2024/baseplate_1x12.stl openscad/baseplate_1x12.scad
 ```
 

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -113,7 +113,7 @@ bin(
 |------|--------|
 | checkout | actions/checkout@v4 |
 | setup OpenSCAD | Use Docker image openscad/openscad:latest |
-| build | install openscad via apt and run `openscad` per file |
+| build | install openscad and xvfb via apt; run `xvfb-run openscad` per file |
 | matrix | Years = [2021…2025]; pass -Dyear=… if future parameterisation needed |
 | artefacts | Upload each rendered STL; optionally commit to stl/YYYY/ on main via ad-m/github-push-action@v0.8.0. |
 
@@ -137,19 +137,23 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Install OpenSCAD
-      run: sudo apt-get update && sudo apt-get install -y openscad
+    - name: Install OpenSCAD + Xvfb
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends openscad xvfb
     - name: Build STL
       run: |
         mkdir -p stl/${{ matrix.year }}
-        openscad -o stl/${{ matrix.year }}/baseplate_1x12.stl \
-          openscad/baseplate_1x12.scad --export-format binstl
+        xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" \
+          openscad -o stl/${{ matrix.year }}/baseplate_1x12.stl \
+            openscad/baseplate_1x12.scad --export-format binstl
 ```
 
 The action internally calls
 
 ```
-openscad -o stl/$year/baseplate_1x12.stl openscad/baseplate_1x12.scad --export-format binstl
+xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" \
+  openscad -o stl/$year/baseplate_1x12.stl openscad/baseplate_1x12.scad --export-format binstl
 ```
 
 ---

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -5,3 +5,4 @@ def test_build_stl_upload_step():
     wf = Path(".github/workflows/build-stl.yml").read_text()
     assert "actions/upload-artifact" in wf
     assert "path: stl/${{ matrix.year }}/baseplate_1x12.stl" in wf
+    assert "xvfb-run" in wf


### PR DESCRIPTION
## Summary
- install OpenSCAD and Xvfb in the STL build workflow
- run `openscad` via `xvfb-run`
- document the updated workflow and local build instructions
- ensure tests expect `xvfb-run`

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c42c59504832fb7ad03a8bd65d7eb