### PR TITLE
Fix OpenSCAD library includes

### DIFF
--- a/openscad/baseplate_1x12.scad
+++ b/openscad/baseplate_1x12.scad
@@ -1,7 +1,7 @@
 // openscad/baseplate_1x12.scad
 // Render with:  openscad -o ../stl/YYYY/baseplate_1x12.stl $fn=120 baseplate_1x12.scad
 
-use <lib/gridfinity-rebuilt/gridfinity-rebuilt-baseplate.scad>;
+include <lib/gridfinity-rebuilt/gridfinity-rebuilt-baseplate.scad>;
 
 units_x = 12;
 units_y = 1;

--- a/openscad/contrib_cube.scad
+++ b/openscad/contrib_cube.scad
@@ -1,5 +1,5 @@
 // openscad/contrib_cube.scad
-use <lib/gridfinity-rebuilt/gridfinity-rebuilt-bin.scad>;
+include <lib/gridfinity-rebuilt/gridfinity-rebuilt-bin.scad>;
 
 bin(
     ux = 1, uy = 1, uh = 1,              // 1×1 base, 1 unit high


### PR DESCRIPTION
## Summary
- include gridfinity library instead of use so variables load

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c450b0c24832f9f45516bc73356dc