### PR TITLE
Fix headless OpenSCAD usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@ Run `black --check .` and `pytest -q` before submitting changes.
 The `build-stl` workflow runs on every push to `main` and attaches the rendered
 STL files as downloadable artifacts. Navigate to the workflow run and download
 `stl-<year>` to obtain the converted models.
+## Troubleshooting
+
+OpenSCAD exits with status 1 when it cannot access an X display. On CI this is handled automatically, but for headless local machines you must wrap the command in `xvfb-run`:
+
+```bash
+xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" \
+  openscad -o output.stl input.scad
+```

--- a/tests/test_scad.py
+++ b/tests/test_scad.py
@@ -63,8 +63,51 @@ def test_scad_to_stl_calls_openscad(monkeypatch, tmp_path):
         called["cmd"] = cmd
 
     monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setenv("DISPLAY", ":0")
     scad_to_stl(str(scad), str(stl))
     assert called["cmd"] == ["openscad", "-o", str(stl), str(scad)]
+
+
+def test_scad_to_stl_uses_xvfb(monkeypatch, tmp_path):
+    scad = tmp_path / "m.scad"
+    stl = tmp_path / "m.stl"
+    scad.write_text("cube(1);")
+
+    def which(binary):
+        if binary == "openscad":
+            return "/usr/bin/openscad"
+        if binary == "xvfb-run":
+            return "/usr/bin/xvfb-run"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    called = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    scad_to_stl(str(scad), str(stl))
+    assert called["cmd"][0] == "xvfb-run"
+
+
+def test_scad_to_stl_no_xvfb(monkeypatch, tmp_path):
+    scad = tmp_path / "m.scad"
+    stl = tmp_path / "m.stl"
+    scad.write_text("cube(1);")
+
+    def which(binary):
+        if binary == "openscad":
+            return "/usr/bin/openscad"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    monkeypatch.delenv("DISPLAY", raising=False)
+
+    with pytest.raises(RuntimeError):
+        scad_to_stl(str(scad), str(stl))
 
 
 def test_generate_scad():


### PR DESCRIPTION
## Summary
- wrap OpenSCAD CLI in `xvfb-run` when `$DISPLAY` is missing
- test new fallback behaviour and the failure case when `xvfb-run` is unavailable
- document how to run OpenSCAD headless

## Testing
- `black --check .`
- `pip install -e .`
- `pytest -q`
- `pytest --cov=gitshelves --cov-report=term -q`

------
https://chatgpt.com/codex/tasks/task_e_688c450b0c24832f9f45516bc73356dc