### PR TITLE
Fix headless OpenSCAD usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - `tests/` pytest suite
 - `docs/` additional documentation
 - `.github/workflows/build-stl.yml` removes any existing Gridfinity library folder, clones the library, installs OpenSCAD and Xvfb via `apt`, renders STL files from SCAD sources using `xvfb-run`, and uploads them as workflow artifacts
+- `scad_to_stl` wraps `openscad` in `xvfb-run` automatically when `$DISPLAY` is missing to mirror the CI workflow
 - `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library. CI clones it automatically; clone it manually for local builds
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs und
 # Clone the Gridfinity library locally (the CI workflow does this automatically)
 git clone https://github.com/kennetek/gridfinity-rebuilt-openscad \
     openscad/lib/gridfinity-rebuilt
-# Wrap with `xvfb-run` if running on a headless server
+# `scad_to_stl` automatically wraps `openscad` in `xvfb-run` when `$DISPLAY`
+# is missing, matching the CI configuration. Ensure `xvfb-run` is installed on
+# headless systems.
 openscad -o stl/2024/baseplate_1x12.stl openscad/baseplate_1x12.scad
 ```
 
@@ -60,3 +62,9 @@ Run `black --check .` and `pytest -q` before submitting changes.
 The `build-stl` workflow runs on every push to `main` and attaches the rendered
 STL files as downloadable artifacts. Navigate to the workflow run and download
 `stl-<year>` to obtain the converted models.
+## Troubleshooting
+
+OpenSCAD exits with status 1 when it cannot access an X display. The
+`scad_to_stl` helper wraps the command in `xvfb-run` when `$DISPLAY` is
+missing. Install `xvfb-run` if you still encounter this error on a headless
+machine.

--- a/tests/test_scad.py
+++ b/tests/test_scad.py
@@ -63,8 +63,50 @@ def test_scad_to_stl_calls_openscad(monkeypatch, tmp_path):
         called["cmd"] = cmd
 
     monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setenv("DISPLAY", ":0")
     scad_to_stl(str(scad), str(stl))
     assert called["cmd"] == ["openscad", "-o", str(stl), str(scad)]
+
+
+def test_scad_to_stl_uses_xvfb(monkeypatch, tmp_path):
+    scad = tmp_path / "m.scad"
+    stl = tmp_path / "m.stl"
+    scad.write_text("cube(1);")
+
+    def which(binary):
+        if binary == "openscad":
+            return "/usr/bin/openscad"
+        if binary == "xvfb-run":
+            return "/usr/bin/xvfb-run"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    called = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    scad_to_stl(str(scad), str(stl))
+    assert called["cmd"][0] == "xvfb-run"
+
+
+def test_scad_to_stl_xvfb_missing(monkeypatch, tmp_path):
+    scad = tmp_path / "m.scad"
+    stl = tmp_path / "m.stl"
+    scad.write_text("cube(1);")
+
+    def which(binary):
+        if binary == "openscad":
+            return "/usr/bin/openscad"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    with pytest.raises(RuntimeError):
+        scad_to_stl(str(scad), str(stl))
 
 
 def test_generate_scad():


### PR DESCRIPTION
## Summary
- document automatic `xvfb-run` fallback in AGENTS.md and README
- test error when `xvfb-run` is missing

## Testing
- `black --check .`
- `pytest -q`
- `pytest --cov=gitshelves --cov-report=term -q`

------
https://chatgpt.com/codex/tasks/task_e_688c450b0c24832f9f45516bc73356dc