### PR TITLE
docs: reference vector76 gridfinity repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs und
 ## Dependencies
 
  - [Gridfinity-Rebuilt-OpenSCAD](https://github.com/kennetek/gridfinity-rebuilt-openscad) – parametric Gridfinity modules. The CI workflow clones this repo into `openscad/lib/gridfinity-rebuilt` when building STL files.
+- [gridfinity_openscad](https://github.com/vector76/gridfinity_openscad) – canonical reference for Gridfinity dimensions and features.
 - [OpenSCAD](https://openscad.org/) ≥ 2024.06 – required to render STL files.
 - GitHub Actions installs `openscad` with `xvfb` to convert `.scad` sources to binary STL outputs in a headless environment.
 

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -5,8 +5,9 @@
 
 ## 1  Background & Goal
 
-`gitshelves` visualises personal GitHub activity as physical objects.  
+`gitshelves` visualises personal GitHub activity as physical objects.
 This iteration makes the project **Gridfinity-compatible** so that the printed parts integrate with the de-facto 42 × 42 mm modular storage standard.
+Dimensions and clearances follow the [vector76/gridfinity_openscad](https://github.com/vector76/gridfinity_openscad) reference implementation.
 We want:
 
 * **stl/** at repo root  
@@ -190,6 +191,7 @@ Official community spec summary – Printables
 Magnet polarity guidelines – Reddit
 Extended spec & stacking lip debate – Reddit
 Parametric OpenSCAD libraries – GitHub
+vector76/gridfinity_openscad – canonical reference implementation
 Chris’s Notes
 Gridfinity primer articles – All3DP
 gridfinity.perplexinglabs.com


### PR DESCRIPTION
## Summary
- note vector76/gridfinity_openscad as the canonical reference for Gridfinity dimensions
- document the reference in `gridfinity_design.md` and README

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee229c918832f9ba9218fce99ea6d