### PR TITLE
Restore gridfinity-rebuilt library with vector76 guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - `docs/` additional documentation
 - `.github/workflows/build-stl.yml` removes any existing Gridfinity library folder, clones the library, installs OpenSCAD and Xvfb via `apt`, renders STL files from SCAD sources using `xvfb-run`, and uploads them as workflow artifacts
 - `scad_to_stl` wraps `openscad` in `xvfb-run` automatically when `$DISPLAY` is missing to mirror the CI workflow
-- `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library. CI clones it automatically; clone it manually for local builds
+- `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library (MIT). CI clones it automatically; clone it manually for local builds and keep the `LICENSE` file. We consult vector76/gridfinity_openscad for guidance
 
 ## Coding Conventions
 - Python code is formatted with `black`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs und
  - [Gridfinity-Rebuilt-OpenSCAD](https://github.com/kennetek/gridfinity-rebuilt-openscad) – parametric Gridfinity modules. The CI workflow clones this repo into `openscad/lib/gridfinity-rebuilt` when building STL files.
 - [OpenSCAD](https://openscad.org/) ≥ 2024.06 – required to render STL files.
 - GitHub Actions installs `openscad` with `xvfb` to convert `.scad` sources to binary STL outputs in a headless environment.
+- [vector76/gridfinity_openscad](https://github.com/vector76/gridfinity_openscad) – reference implementation we consult for specification details (MIT).
 
 ## How to Build Locally
 

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -59,7 +59,7 @@ gitshelves/
 ## 4  OpenSCAD Implementation Details
 
 ### 4.1  Third-party library  
-Use **kennetek/gridfinity-rebuilt-openscad** (MIT) as a submodule, providing canonical modules `gridfinityBaseplate()` and `bin()`.
+Use **kennetek/gridfinity-rebuilt-openscad** (MIT) as a submodule, providing canonical modules `gridfinityBaseplate()` and `bin()`. We also consult **vector76/gridfinity_openscad** (MIT) for additional design guidance.
 
 ```scad
 // openscad/baseplate_1x12.scad
@@ -190,6 +190,7 @@ Official community spec summary – Printables
 Magnet polarity guidelines – Reddit
 Extended spec & stacking lip debate – Reddit
 Parametric OpenSCAD libraries – GitHub
+vector76/gridfinity_openscad – GitHub
 Chris’s Notes
 Gridfinity primer articles – All3DP
 gridfinity.perplexinglabs.com
@@ -203,12 +204,13 @@ GitHub Action wrapper for OpenSCAD – GitHub
 ## Codex Prompt (paste verbatim)
 
 > **System**: You are a senior DevOps & CAD automation engineer.  
-> **User**:  
-> 1. Clone `https://github.com/futuroptimist/gitshelves`.  
-> 2. Add submodule `kennetek/gridfinity-rebuilt-openscad` at `openscad/lib/gridfinity-rebuilt`.  
-> 3. Create `openscad/baseplate_1x12.scad` and `openscad/contrib_cube.scad` per the spec in `docs/gridfinity_design.md`.  
-> 4. Generate folders `stl/{2021..2025}` (keep empty – CI will fill).  
-> 5. Add `.github/workflows/build-stl.yml` implementing the matrix build using apt-installed OpenSCAD; output binary STLs.
-> 6. Update root `README.md` to include a *Dependencies* and *How to Build Locally* section.  
-> 7. Commit, sign off (`git commit -s`), and open a pull-request titled “Gridfinity support & automated STL builds”.  
+> **User**:
+> 1. Clone `https://github.com/futuroptimist/gitshelves`.
+> 2. Add submodule `kennetek/gridfinity-rebuilt-openscad` at `openscad/lib/gridfinity-rebuilt`.
+> 3. Review `vector76/gridfinity_openscad` for design guidance; do not vendor its sources.
+> 4. Create `openscad/baseplate_1x12.scad` and `openscad/contrib_cube.scad` per the spec in `docs/gridfinity_design.md`.
+> 5. Generate folders `stl/{2021..2025}` (keep empty – CI will fill).
+> 6. Add `.github/workflows/build-stl.yml` implementing the matrix build using apt-installed OpenSCAD; output binary STLs.
+> 7. Update root `README.md` to include a *Dependencies* and *How to Build Locally* section.
+> 8. Commit, sign off (`git commit -s`), and open a pull-request titled “Gridfinity support & automated STL builds”.
 > **Assistant**: implement every step and show the diff.

--- a/openscad/baseplate_1x12.scad
+++ b/openscad/baseplate_1x12.scad
@@ -1,6 +1,8 @@
 // openscad/baseplate_1x12.scad
 // Render with:  openscad -o ../stl/YYYY/baseplate_1x12.stl $fn=120 baseplate_1x12.scad
 
+// Dimensions cross-checked with vector76/gridfinity_openscad.
+
 include <lib/gridfinity-rebuilt/gridfinity-rebuilt-baseplate.scad>;
 
 units_x = 12;

--- a/openscad/contrib_cube.scad
+++ b/openscad/contrib_cube.scad
@@ -1,4 +1,5 @@
 // openscad/contrib_cube.scad
+// Dimensions cross-checked with vector76/gridfinity_openscad.
 include <lib/gridfinity-rebuilt/gridfinity-rebuilt-bin.scad>;
 
 bin(

--- a/openscad/lib/gridfinity-rebuilt/LICENSE
+++ b/openscad/lib/gridfinity-rebuilt/LICENSE
@@ -1,0 +1,46 @@
+MIT License
+
+Copyright (c) 2023 Kenneth Hodson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+This repository is based on Gridfinity:
+
+MIT License
+
+Copyright (c) 2023 Zachary Freedman and Voidstar Lab LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/openscad/lib/gridfinity-rebuilt/README.md
+++ b/openscad/lib/gridfinity-rebuilt/README.md
@@ -1,2 +1,11 @@
 This directory should contain the Gridfinity-Rebuilt-OpenSCAD library.
-TODO: add as a submodule or vendor when distributing.
+
+Clone with:
+```
+git clone https://github.com/kennetek/gridfinity-rebuilt-openscad \
+    openscad/lib/gridfinity-rebuilt
+```
+
+We cross-check dimensions against vector76/gridfinity_openscad for additional guidance.
+
+The Gridfinity-Rebuilt library is MIT licensed; see LICENSE.


### PR DESCRIPTION
## Summary
- return to kennetek/gridfinity-rebuilt-openscad as the Gridfinity library and include its MIT license
- document vector76/gridfinity_openscad as a reference for Gridfinity specs across docs and SCAD examples

## Testing
- `pip install -e .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee229c918832f9ba9218fce99ea6d