### PR TITLE
Generate STL artifacts in CI

### DIFF
--- a/.github/workflows/build-stl.yml
+++ b/.github/workflows/build-stl.yml
@@ -3,6 +3,8 @@ name: build-stl
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - `gitshelves/` Python package with CLI modules
 - `tests/` pytest suite
 - `docs/` additional documentation
-- `.github/workflows/build-stl.yml` removes any existing Gridfinity library folder, clones the library, installs OpenSCAD and Xvfb via `apt`, renders STL files from SCAD sources using `xvfb-run`, and uploads them as workflow artifacts
+- `.github/workflows/build-stl.yml` runs on pushes and pull requests to `main`, removes any existing Gridfinity library folder, clones the library, installs OpenSCAD and Xvfb via `apt`, renders STL files from SCAD sources using `xvfb-run`, and uploads them as workflow artifacts
 - `scad_to_stl` wraps `openscad` in `xvfb-run` automatically when `$DISPLAY` is missing to mirror the CI workflow
 - `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library (MIT). CI clones it automatically; clone it manually for local builds and keep the `LICENSE` file. We consult vector76/gridfinity_openscad for guidance
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Run `black --check .` and `pytest -q` before submitting changes.
 
 ## STL Build Outputs
 
-The `build-stl` workflow runs on every push to `main` and attaches the rendered
-STL files as downloadable artifacts. Navigate to the workflow run and download
-`stl-<year>` to obtain the converted models.
+The `build-stl` workflow runs on every push and pull request targeting `main`
+and attaches the rendered STL files as downloadable artifacts. Navigate to the
+workflow run and download `stl-<year>` to obtain the converted models.
 ## Troubleshooting
 
 OpenSCAD exits with status 1 when it cannot access an X display. The


### PR DESCRIPTION
## Summary
- run `build-stl` workflow on pushes and pull requests to main to produce STL artifacts
- document workflow triggers in `AGENTS.md` and `README.md`

## Testing
- `black --check .`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef8506b30832f899628c43b19ca99