### PR TITLE
docs: add repo feature summary prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 ## Project Structure
 - `gitshelves/` Python package with CLI modules
 - `tests/` pytest suite
-- `docs/` additional documentation
+- `docs/` additional documentation and prompts
 - `.github/workflows/build-stl.yml` runs on pushes and pull requests to `main`, removes any existing Gridfinity library folder, clones the library, installs OpenSCAD and Xvfb via `apt`, renders `openscad/baseplate_2x6.scad` to `stl/<year>/baseplate_2x6.stl` using `xvfb-run`, and uploads them as workflow artifacts
 - `scad_to_stl` wraps `openscad` in `xvfb-run` automatically when `$DISPLAY` is missing to mirror the CI workflow
 - `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library (MIT). CI clones it automatically; clone it manually for local builds and keep the `LICENSE` file. We consult vector76/gridfinity_openscad for guidance

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,7 @@
 The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes.
 Use `--months-per-row` to control the grid width and `--stl` to specify an STL
 output path.
+
+## Prompts
+
+- [Repo feature summary prompt](repo_feature_summary_prompt.md) – collect data for flywheel's feature matrix.

--- a/docs/repo_feature_summary_prompt.md
+++ b/docs/repo_feature_summary_prompt.md
@@ -1,0 +1,24 @@
+# Repo Feature Summary Prompt
+
+Use this prompt to gather the data required for flywheel's `repo-feature-summary.md`.
+
+## Codex Prompt (paste verbatim)
+
+> **System**: You analyze GitHub repositories for flywheel feature adoption.
+> **User**:
+> 1. Clone `https://github.com/futuroptimist/gitshelves`.
+> 2. Report the following in a single table row:
+>    - default branch name
+>    - latest commit short SHA
+>    - whether the latest commit has passing CI (Trunk)
+>    - test coverage percentage
+>    - whether patch coverage ≥ 90%
+>    - presence of a `codecov.yml` file or Codecov badge
+>    - primary installation method (pip, uv, etc.)
+>    - existence of `LICENSE`, `AGENTS.md`, `CODE_OF_CONDUCT.md`,
+>      `CONTRIBUTING.md`, and `pre-commit` config
+>    - number of GitHub Actions workflows
+>    - counts of dark patterns and bright patterns (use `flywheel` scanning tools if available)
+>    - last updated date (UTC) of the commit
+> 3. Output the table row using the format in `flywheel/docs/repo-feature-summary.md`.
+> **Assistant**: Execute all steps and show your work.

--- a/llms.txt
+++ b/llms.txt
@@ -15,6 +15,7 @@ Important notes:
 - [README](README.md): usage instructions
 - [Agent guide](AGENTS.md): workflow for contributors and LLMs
 - [Project docs](docs/index.md): CLI options overview
+- [Repo feature summary prompt](docs/repo_feature_summary_prompt.md): gather flywheel matrix data
 
 ## Optional
 - [GitHub repo](https://github.com/futuroptimist/gitshelves): issues and source


### PR DESCRIPTION
## Summary
- document new repo feature summary prompt for flywheel's feature matrix
- expose prompt via docs index and llms.txt
- note docs directory now hosts prompts

## Testing
- `black --check .`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689067a46ba0832fb14c076440d93984