### PR TITLE
feat: summarize materials per year

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The `build-stl` workflow runs on every push and pull request targeting `main`
 and attaches the rendered STL files as downloadable artifacts. Navigate to the
 workflow run and download `stl-<year>` to obtain the converted models.
 To avoid bloating the repository, pre-generated baseplate models are no longer stored in the repo. Download the `stl-<year>` artifact or generate them locally.
+Each `stl/<year>` directory includes a generated `README.md` summarizing the baseplate and monthly cube counts.
 ## Troubleshooting
 
 OpenSCAD exits with status 1 when it cannot access an X display. The

--- a/gitshelves/cli.py
+++ b/gitshelves/cli.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from .fetch import fetch_user_contributions
 from .scad import generate_scad_monthly, scad_to_stl
+from .readme import write_year_readme
 
 
 def main():
@@ -42,6 +43,9 @@ def main():
         dt = datetime.fromisoformat(d)
         key = (dt.year, dt.month)
         counts[key] = counts.get(key, 0) + 1
+
+    for year in {y for y, _ in counts}:
+        write_year_readme(year, counts)
 
     scad_text = generate_scad_monthly(counts, months_per_row=args.months_per_row)
     Path(args.output).write_text(scad_text)

--- a/gitshelves/readme.py
+++ b/gitshelves/readme.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, Tuple
+
+from .scad import blocks_for_contributions
+
+
+def write_year_readme(
+    year: int,
+    counts: Dict[Tuple[int, int], int],
+    outdir: Path | str = Path("stl"),
+) -> Path:
+    """Write a README detailing materials for ``year``.
+
+    A summary of the baseplate STL and monthly cube counts is written to
+    ``stl/<year>/README.md``. The function returns the path to the created file.
+    """
+    path = Path(outdir) / str(year)
+    path.mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        f"# {year} Materials",
+        "",
+        "## Baseplate",
+        "- [`baseplate_2x6.stl`](baseplate_2x6.stl)",
+        "",
+        "## Monthly Cubes",
+    ]
+    for month in range(1, 13):
+        count = counts.get((year, month), 0)
+        cubes = blocks_for_contributions(count)
+        name = datetime(year, month, 1).strftime("%B")
+        lines.append(
+            f"- {name}: {count} contributions \u2192 {cubes} cube{'s' if cubes != 1 else ''}"
+        )
+
+    lines += [
+        "",
+        "## Versions",
+        "- `monthly-5x6`: zoomed view of days per month in 5×6 grid (256 mm³)",
+    ]
+
+    readme_path = path / "README.md"
+    readme_path.write_text("\n".join(lines))
+    return readme_path

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,9 @@
+from gitshelves.readme import write_year_readme
+
+
+def test_write_year_readme(tmp_path):
+    counts = {(2023, 1): 5, (2023, 2): 20}
+    readme = write_year_readme(2023, counts, outdir=tmp_path)
+    text = readme.read_text()
+    assert "January: 5 contributions" in text
+    assert "February: 20 contributions" in text


### PR DESCRIPTION
## Summary
- generate per-year materials README in `stl/<year>`
- wire CLI to emit yearly README after fetching contributions
- document generated year folders and add test for README creation

## Testing
- `pre-commit run --all-files` *(fails: .pre-commit-config.yaml is not a file)*
- `black --check .`
- `pytest -q`
- `npm test -- --coverage` *(fails: package.json not found)*
- `python -m flywheel.fit` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_689148a990a4832fb5dee71dde308fb3