### PR TITLE
📝: add codex prompt docs

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,0 +1,11 @@
+# Prompt Docs Summary
+
+This index lists prompt documents for the Gitshelves repository.
+
+| Document | Title |
+|----------|-------|
+| [prompts-codex.md](./prompts-codex.md) | Gitshelves Codex Prompt |
+| [prompts-codex-ci-fix.md](./prompts-codex-ci-fix.md) | Codex CI-Failure Fix Prompt |
+| [repo_feature_summary_prompt.md](./repo_feature_summary_prompt.md) | Repo Feature Summary Prompt |
+
+_Updated manually: 2025-08-06_

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -1,0 +1,27 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug: 'prompts-codex-ci-fix'
+---
+
+# Codex CI-Failure Fix Prompt
+
+Use this prompt when CI fails and you want an automated agent to fix the issue.
+
+```
+SYSTEM: You are an automated contributor for the Gitshelves repository.
+
+GOAL
+Diagnose and resolve the failing check.
+
+REQUIREMENTS
+1. Reproduce the failure locally.
+2. Apply a minimal fix.
+3. Add a regression test when practical.
+4. Ensure `black --check .` and `pytest -q` pass.
+
+ACCEPTANCE_CHECK
+`black --check .` and `pytest -q` succeed with no failures.
+
+OUTPUT
+Return only the patch.
+```

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,35 @@
+---
+title: 'Gitshelves Codex Prompt'
+slug: 'prompts-codex'
+---
+
+# Codex Automation Prompt
+
+Use this baseline prompt when instructing an automated agent to improve the Gitshelves repository.
+
+```
+SYSTEM:
+You are an automated contributor for the Gitshelves repository.
+ASSISTANT: (DEV) Implement code; stop after producing patch.
+ASSISTANT: (CRITIC) Inspect the patch and JSON manifest; reply only "LGTM"
+or a bullet list of fixes needed.
+
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow the conventions in AGENTS.md and README.md.
+- Ensure `black --check .` and `pytest -q` succeed.
+
+REQUEST:
+1. Identify a simple improvement or bug fix.
+2. Implement the change using the existing project style.
+3. Update documentation as needed.
+4. Run the commands listed above.
+
+ACCEPTANCE_CHECK:
+{"patch":"<unified diff>", "summary":"<80-char msg>", "tests_pass":true}
+
+OUTPUT_FORMAT:
+The DEV assistant must output the JSON object first, then the diff in a fenced diff block.
+```


### PR DESCRIPTION
what: add baseline and CI-fix Codex prompts with summary index
why: seed gitshelves with reusable automation prompts
how to test: black --check . && pytest -q

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6893e30966f0832f8e0f19696fc0d2fd