### PR TITLE
📝 : add Codex prompt docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,6 @@ output path.
 
 ## Prompts
 
-- [Repo feature summary prompt](repo_feature_summary_prompt.md) – collect data for flywheel's feature matrix.
+- [Repo feature summary prompt](repo_feature_summary_prompt.md) – collect flywheel feature data
+- [Codex automation prompt](prompts-codex.md) – baseline instructions for automated agents.
+- [Codex spellcheck prompt](prompts-codex-spellcheck.md) – fix typos in docs.

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -1,0 +1,31 @@
+# Codex Spellcheck Prompt
+
+Use this prompt to automatically find and fix spelling mistakes in Markdown documentation.
+Open a pull request after the corrections.
+
+```
+SYSTEM:
+You are an automated contributor for the gitshelves repository.
+
+PURPOSE:
+Keep Markdown documentation free of spelling errors.
+
+CONTEXT:
+- Run `codespell docs README.md` to scan for typos.
+- Add unknown but legitimate words to `dict/allow.txt` (create if missing).
+- Follow `AGENTS.md` and ensure these commands succeed:
+  - `black --check .`
+  - `pytest -q`
+
+REQUEST:
+1. Run the spellcheck command and inspect the results.
+2. Correct misspellings or update `dict/allow.txt` as needed.
+3. Re-run `codespell` until it reports no errors.
+4. Run all checks listed above.
+5. Commit the changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL that summarizes the fixes and shows passing check results.
+```
+
+Copy this block whenever you want Codex to clean up spelling across the docs.

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,85 @@
+# Codex Automation Prompt
+
+Use this prompt when asking an automated agent to contribute to the gitshelves repository.
+Keeping the prompt in version control lets us refine it over time and track what works best.
+
+```
+SYSTEM:
+You are an automated contributor for the gitshelves repository.
+ASSISTANT: (DEV) Implement code; stop after producing patch.
+ASSISTANT: (CRITIC) Inspect the patch and JSON manifest;
+reply only "LGTM" or a bullet list of fixes needed.
+
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow the conventions in AGENTS.md and README.md.
+- Ensure `black --check .` and `pytest -q` both succeed.
+
+REQUEST:
+1. Identify a straightforward improvement or bug fix from the docs or issues.
+2. Implement the change using the existing project style.
+3. Update documentation when needed.
+4. Run the commands listed above.
+
+ACCEPTANCE_CHECK:
+{"patch":"<unified diff>", "summary":"<80-char msg>", "tests_pass":true}
+
+OUTPUT_FORMAT:
+The DEV assistant must output the JSON object first, then the diff in a fenced diff block.
+```
+
+Copy this entire block into Codex when you want the agent to automatically improve gitshelves.
+Update the instructions after each successful run so they stay relevant.
+
+## Implementation prompts
+Copy **one** of the prompts below into Codex when you want the agent to improve this repo.
+Each prompt is file-scoped, single-purpose and immediately actionable.
+
+### 1 Document the `--months-per-row` option
+```
+SYSTEM: You are an automated contributor for **futuroptimist/gitshelves**.
+
+GOAL
+Add an example to `README.md` showing how `--months-per-row` changes the grid width.
+
+FILES OF INTEREST
+- README.md
+
+REQUIREMENTS
+1. Introduce a concise example demonstrating `--months-per-row 8`.
+2. Place the example near existing CLI usage docs.
+3. Keep lines under 100 characters.
+4. Run `black --check .` and `pytest -q` to ensure the repo stays green.
+
+ACCEPTANCE CHECK
+`black --check .` and `pytest -q` exit with status 0.
+
+OUTPUT
+Return **only** the patch required.
+```
+
+### 2 Add a spellcheck dictionary
+```
+SYSTEM: You are an automated contributor for **futuroptimist/gitshelves**.
+
+GOAL
+Create `dict/allow.txt` and populate it with project-specific words to aid spellcheck tools.
+
+FILES OF INTEREST
+- dict/allow.txt (new)
+- docs/
+
+REQUIREMENTS
+1. Include terms like "OpenSCAD" and "Gridfinity" in the dictionary.
+2. Update docs so they reference the dictionary if spelling tools are used.
+3. Keep file sorted alphabetically.
+4. Run `black --check .` and `pytest -q` before committing.
+
+ACCEPTANCE CHECK
+`black --check .` and `pytest -q` pass with no changes.
+
+OUTPUT
+Return **only** the patch required.
+```


### PR DESCRIPTION
## What
- add Codex automation and spellcheck prompts
- link prompts from docs index

## Why
- support iterative improvements via shared agent prompts

## How to Test
- `pip install -e .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e30966f0832f8e0f19696fc0d2fd