### PR TITLE
📝: add allowlist for spellcheck

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -1,0 +1,4 @@
+Gitshelves
+Gridfinity
+OpenSCAD
+Xvfb

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,3 +10,8 @@ output path, and `--colors` to split blocks into up to four color groups.
 - [Repo feature summary prompt](repo_feature_summary_prompt.md) – collect flywheel feature data
 - [Codex automation prompt](prompts-codex.md) – baseline instructions for automated agents.
 - [Codex spellcheck prompt](prompts-codex-spellcheck.md) – fix typos in docs.
+
+## Spellcheck
+
+Run `codespell` to catch typos. Project-specific words such as OpenSCAD and
+Gridfinity live in `dict/allow.txt`.

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -12,7 +12,8 @@ Keep Markdown documentation free of spelling errors.
 
 CONTEXT:
 - Run `codespell docs README.md` to scan for typos.
-- Add unknown but legitimate words to `dict/allow.txt` (create if missing).
+ - Add unknown but legitimate words to `dict/allow.txt`, keeping entries
+   sorted alphabetically.
 - Follow `AGENTS.md` and ensure these commands succeed:
   - `black --check .`
   - `pytest -q`


### PR DESCRIPTION
## Summary
- add dict/allow.txt with project-specific words
- document codespell allowlist and alphabetical rule

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57ca390b4832f9a6fd309bce3eda3