### PR TITLE
🩹 fix test imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration to ensure the package is importable during tests."""
+
+import sys
+from pathlib import Path
+
+# Add repository root to sys.path so tests can import gitshelves without installation
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,4 @@ import sys
 from pathlib import Path
 
 # Add repository root to sys.path so tests can import gitshelves without installation
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))


### PR DESCRIPTION
## Summary
- ensure tests can import gitshelves without installation by adding repo root to sys.path

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57c75f324832f9e69cab7a5842e5c