### PR TITLE
🐛 : – validate year range for fetch

### DIFF
--- a/gitshelves/fetch.py
+++ b/gitshelves/fetch.py
@@ -19,6 +19,8 @@ def fetch_user_contributions(
     """
     end = datetime.utcnow().year if end_year is None else end_year
     start = end if start_year is None else start_year
+    if start > end:
+        raise ValueError("start_year cannot be after end_year")
     start_date = datetime(start, 1, 1)
     end_date = datetime(end, 12, 31)
     query = f"author:{username} created:{start_date.strftime('%Y-%m-%d')}..{end_date.strftime('%Y-%m-%d')}"

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import types
+import pytest
 
 import gitshelves.fetch as fetch
 
@@ -72,3 +73,8 @@ def test_fetch_multiple_pages_with_token(monkeypatch):
     assert headers_used[0]["Authorization"] == "token T"
     assert items == [{"page": 1}, {"page": 2}]
     assert "2021-01-01" in queries[0]
+
+
+def test_fetch_invalid_year_range():
+    with pytest.raises(ValueError):
+        fetch.fetch_user_contributions("me", start_year=2022, end_year=2021)


### PR DESCRIPTION
## Summary
- raise `ValueError` when start_year exceeds end_year in GitHub query
- cover invalid year range with regression test

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a813b887f0832fafb4ddb8ad05c368