### PR TITLE
Fix headless DISPLAY handling in scad_to_stl

### DIFF
--- a/gitshelves/scad.py
+++ b/gitshelves/scad.py
@@ -159,7 +159,7 @@ def scad_to_stl(scad_file: str, stl_file: str) -> None:
         raise FileNotFoundError("openscad not found")
 
     cmd = ["openscad", "-o", stl_file, scad_file]
-    if "DISPLAY" not in os.environ:
+    if not os.environ.get("DISPLAY"):
         if shutil.which("xvfb-run") is None:
             raise RuntimeError("xvfb-run required for headless rendering")
         cmd = [

--- a/tests/test_scad.py
+++ b/tests/test_scad.py
@@ -141,6 +141,31 @@ def test_scad_to_stl_uses_xvfb(monkeypatch, tmp_path):
     assert called["cmd"][0] == "xvfb-run"
 
 
+def test_scad_to_stl_empty_display(monkeypatch, tmp_path):
+    scad = tmp_path / "m.scad"
+    stl = tmp_path / "m.stl"
+    scad.write_text("cube(1);")
+
+    def which(binary):
+        if binary == "openscad":
+            return "/usr/bin/openscad"
+        if binary == "xvfb-run":
+            return "/usr/bin/xvfb-run"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    monkeypatch.setenv("DISPLAY", "")
+    called = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    scad_to_stl(str(scad), str(stl))
+    assert called["cmd"][0] == "xvfb-run"
+
+
 def test_scad_to_stl_xvfb_missing(monkeypatch, tmp_path):
     scad = tmp_path / "m.scad"
     stl = tmp_path / "m.stl"


### PR DESCRIPTION
## Summary
- wrap openscad with xvfb when DISPLAY is empty
- cover empty DISPLAY case with regression test

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a813b887f0832fafb4ddb8ad05c368