### PR TITLE
📝 docs: clarify token env var and viewer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,14 @@ Gitshelves fetches GitHub contribution data and turns it into 3D printable model
 ## Usage
 
 1. Install the package in editable mode.
-2. Generate a personal access token from GitHub ("Settings → Developer settings →
-   Personal access tokens") and assign it to `GH_TOKEN`.
-3. Run the CLI to generate a `.scad` file. The token is read from `GH_TOKEN`
-   if `--token` is omitted.
-
-```bash
-GH_TOKEN=<your-token>
-```
+2. Generate a [personal access token](https://github.com/settings/tokens) and export it as
+   `GH_TOKEN`.
+3. Run the CLI to generate a `.scad` file. The token is read from `GH_TOKEN` or
+   `GITHUB_TOKEN` if `--token` is omitted.
 
 ```bash
 pip install -e .
+export GH_TOKEN=<your-token>
 python -m gitshelves.cli <github-username> \
     --start-year 2021 --end-year 2023 \
     --months-per-row 10 --stl contributions.stl --colors 1
@@ -45,7 +42,8 @@ Sep Oct Nov Dec
 
 Use `--colors` to control multi-color outputs. `--colors 2` produces one blocks file and a baseplate for two-color prints. `--colors 3` or `4` group logarithmic levels into additional color files. Each `*_colorN.scad` (`*_colorN.stl`) contains the blocks for a color group.
 
-Open `docs/viewer.html` in a browser to preview generated STL files with Three.js and experiment with different color counts.
+Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with
+Three.js and experiment with different color counts.
 Use the file picker to load your baseplate and level STLs.
 
 If you fork this repository, replace `futuroptimist` with your GitHub username in badge URLs to keep status badges working.

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -1,4 +1,4 @@
-# GitShelves × Gridfinity – Design Specification  
+# Gitshelves × Gridfinity – Design Specification
 *(v0.9 – 2025-07-29)*
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes.
 Use `--months-per-row` to control the grid width, `--stl` to specify an STL
 output path, and `--colors` to split blocks into up to four color groups.
-`docs/viewer.html` previews the resulting STLs in the browser with Three.js.
+[`viewer.html`](viewer.html) previews the resulting STLs in the browser with Three.js.
 
 ## Prompts
 


### PR DESCRIPTION
## Summary
- document GH_TOKEN/GITHUB_TOKEN lookup
- link viewer.html and GitHub token page
- fix Gridfinity spec heading capitalization

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8139ec0a4832f8dc1d3e791bdb66a