### PR TITLE
🧪 : – add readme pluralization and negative contribution tests

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -7,3 +7,12 @@ def test_write_year_readme(tmp_path):
     text = readme.read_text()
     assert "January: 5 contributions" in text
     assert "February: 20 contributions" in text
+
+
+def test_write_year_readme_zero_and_plural(tmp_path):
+    counts = {(2024, 1): 1, (2024, 2): 10}
+    readme = write_year_readme(2024, counts, outdir=tmp_path)
+    text = readme.read_text()
+    assert "January: 1 contributions \u2192 1 cube" in text
+    assert "February: 10 contributions \u2192 2 cubes" in text
+    assert "March: 0 contributions \u2192 0 cubes" in text

--- a/tests/test_scad.py
+++ b/tests/test_scad.py
@@ -19,6 +19,10 @@ def test_blocks_for_contributions():
     assert blocks_for_contributions(100) == 3
 
 
+def test_blocks_for_contributions_negative():
+    assert blocks_for_contributions(-5) == 0
+
+
 def test_generate_scad_monthly():
     counts = {
         (2021, 1): 1,


### PR DESCRIPTION
what: add regression tests for README generation and negative counts
why: ensure zero-month pluralization and negative counts map to zero
how to test: pip install -e . && black --check . && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68a812ae0d18832f83bb77ac69fa7527