### PR TITLE
🐛 : – read token from environment in fetch_user_contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Gitshelves fetches GitHub contribution data and turns it into 3D printable model
 2. Generate a personal access token from GitHub ("Settings → Developer settings →
    Personal access tokens") and assign it to `GH_TOKEN`.
 3. Run the CLI to generate a `.scad` file. The token is read from `GH_TOKEN`
-   if `--token` is omitted.
+   if `--token` is omitted. Library functions such as
+   `fetch_user_contributions` also fall back to `GH_TOKEN` or `GITHUB_TOKEN`
+   when no token is provided.
 
 ```bash
 GH_TOKEN=<your-token>

--- a/gitshelves/fetch.py
+++ b/gitshelves/fetch.py
@@ -15,7 +15,9 @@ def fetch_user_contributions(
     """Fetch contribution data for a user using GitHub's Search API.
 
     Parameters can specify a range of years to query. If no range is
-    provided, only the current year is fetched.
+    provided, only the current year is fetched. When ``token`` is ``None``,
+    the ``GH_TOKEN`` or ``GITHUB_TOKEN`` environment variables are used if
+    set.
     """
     end = datetime.utcnow().year if end_year is None else end_year
     start = end if start_year is None else start_year
@@ -23,9 +25,8 @@ def fetch_user_contributions(
     end_date = datetime(end, 12, 31)
     query = f"author:{username} created:{start_date.strftime('%Y-%m-%d')}..{end_date.strftime('%Y-%m-%d')}"
     url = GITHUB_API
-    headers = {}
-    if token:
-        headers["Authorization"] = f"token {token}"
+    token = token or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    headers = {"Authorization": f"token {token}"} if token else {}
     params = {"q": query, "per_page": 100}
     items = []
     page = 1


### PR DESCRIPTION
## Summary
- allow fetch_user_contributions to use GH_TOKEN/GITHUB_TOKEN env vars
- document token fallback and add unit test

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8128f4d14832fbb885c71d11381eb