### PR TITLE
fix: handle empty DISPLAY in scad_to_stl

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs und
 git clone https://github.com/kennetek/gridfinity-rebuilt-openscad \
     openscad/lib/gridfinity-rebuilt
 # `scad_to_stl` automatically wraps `openscad` in `xvfb-run` when `$DISPLAY`
-# is missing, matching the CI configuration. Ensure `xvfb-run` is installed on
-# headless systems.
+# is unset or empty, matching the CI configuration. Ensure `xvfb-run` is
+# installed on headless systems.
 openscad -o stl/2024/baseplate_2x6.stl openscad/baseplate_2x6.scad
 ```
 
@@ -92,5 +92,5 @@ Each `stl/<year>` directory includes a generated `README.md` summarizing the bas
 
 OpenSCAD exits with status 1 when it cannot access an X display. The
 `scad_to_stl` helper wraps the command in `xvfb-run` when `$DISPLAY` is
-missing. Install `xvfb-run` if you still encounter this error on a headless
+unset or empty. Install `xvfb-run` if you still encounter this error on a headless
 machine.

--- a/gitshelves/scad.py
+++ b/gitshelves/scad.py
@@ -146,10 +146,10 @@ def group_scad_levels(level_scads: Dict[int, str], groups: int) -> Dict[int, str
 def scad_to_stl(scad_file: str, stl_file: str) -> None:
     """Convert ``scad_file`` to ``stl_file`` using the ``openscad`` CLI.
 
-    If the current environment lacks an X display (``$DISPLAY`` is unset), the
-    command is automatically wrapped in ``xvfb-run`` when available. This mirrors
-    the CI configuration and prevents ``openscad`` from exiting with code ``1``
-    on headless servers.
+    If the current environment lacks an X display (``$DISPLAY`` is unset or
+    empty), the command is automatically wrapped in ``xvfb-run`` when
+    available. This mirrors the CI configuration and prevents ``openscad`` from
+    exiting with code ``1`` on headless servers.
     """
     import os
     import shutil
@@ -159,7 +159,7 @@ def scad_to_stl(scad_file: str, stl_file: str) -> None:
         raise FileNotFoundError("openscad not found")
 
     cmd = ["openscad", "-o", stl_file, scad_file]
-    if "DISPLAY" not in os.environ:
+    if not os.environ.get("DISPLAY"):
         if shutil.which("xvfb-run") is None:
             raise RuntimeError("xvfb-run required for headless rendering")
         cmd = [

--- a/tests/test_scad.py
+++ b/tests/test_scad.py
@@ -141,6 +141,31 @@ def test_scad_to_stl_uses_xvfb(monkeypatch, tmp_path):
     assert called["cmd"][0] == "xvfb-run"
 
 
+def test_scad_to_stl_empty_display(monkeypatch, tmp_path):
+    scad = tmp_path / "m.scad"
+    stl = tmp_path / "m.stl"
+    scad.write_text("cube(1);")
+
+    def which(binary):
+        if binary == "openscad":
+            return "/usr/bin/openscad"
+        if binary == "xvfb-run":
+            return "/usr/bin/xvfb-run"
+        return None
+
+    monkeypatch.setattr("shutil.which", which)
+    monkeypatch.setenv("DISPLAY", "")
+    called = {}
+
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    scad_to_stl(str(scad), str(stl))
+    assert called["cmd"][0] == "xvfb-run"
+
+
 def test_scad_to_stl_xvfb_missing(monkeypatch, tmp_path):
     scad = tmp_path / "m.scad"
     stl = tmp_path / "m.stl"


### PR DESCRIPTION
## Summary
- handle empty DISPLAY by wrapping openscad with xvfb-run
- document behavior for empty DISPLAY
- test headless rendering when DISPLAY is empty

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8128f4d14832fbb885c71d11381eb