### PR TITLE
📚 : – document months-per-row grid width

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ python -m gitshelves.cli <github-username> \
     --months-per-row 10 --stl contributions.stl --colors 1
 ```
 
-The command will create `contributions.scad` (and optionally `contributions.stl`) in the current directory. Months are arranged in rows of twelve by default, but you can choose the grid width via `--months-per-row`.
+The command will create `contributions.scad` (and optionally `contributions.stl`) in the current
+directory. Months are arranged in rows of twelve by default, but you can choose the grid width via
+`--months-per-row`.
+
+The default layout fits twelve months on each row:
+
+```
+Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
+```
 
 For instance, `--months-per-row 8` lays out eight months per row:
 


### PR DESCRIPTION
What: illustrate default vs 8-month layout in README.
Why: clarify --months-per-row effect on grid width.
Test: black --check ., pytest -q.


------
https://chatgpt.com/codex/tasks/task_e_68a8129236cc832f86bd29a63432f113