### PR TITLE
docs: crosslink README and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ If you fork this repository, replace `futuroptimist` with your GitHub username i
          ##     ###
 ```
 
-See [AGENTS.md](AGENTS.md) for agent workflow guidelines and additional docs under [docs/](docs/).
+See [AGENTS.md](AGENTS.md) for agent workflow guidelines and
+[docs](docs/index.md) for additional documentation.
 
 ## Dependencies
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Gitshelves Docs
 
+For setup and usage details, see the [README](../README.md).
+
 The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes.
 Use `--months-per-row` to control the grid width, `--stl` to specify an STL
 output path, and `--colors` to split blocks into up to four color groups.


### PR DESCRIPTION
## Summary
- link README to docs index and docs index back to README

## Testing
- `codespell docs/index.md README.md`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92db87a7c832f90f9985f6864e33a