### PR TITLE
📝 docs: refresh token and viewer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Gitshelves fetches GitHub contribution data and turns it into 3D printable model
 ## Usage
 
 1. Install the package in editable mode.
-2. Generate a [personal access token](https://github.com/settings/tokens) and export it as
-   `GH_TOKEN`.
+2. Generate a [personal access token](https://github.com/settings/personal-access-tokens/new)
+   and export it as `GH_TOKEN`.
 3. Run the CLI to generate a `.scad` file. The token is read from `GH_TOKEN` or
    `GITHUB_TOKEN` if `--token` is omitted.
 
@@ -43,7 +43,7 @@ Sep Oct Nov Dec
 Use `--colors` to control multi-color outputs. `--colors 2` produces one blocks file and a baseplate for two-color prints. `--colors 3` or `4` group logarithmic levels into additional color files. Each `*_colorN.scad` (`*_colorN.stl`) contains the blocks for a color group.
 
 Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with
-Three.js and experiment with different color counts.
+[Three.js](https://threejs.org/) and experiment with different color counts.
 Use the file picker to load your baseplate and level STLs.
 
 If you fork this repository, replace `futuroptimist` with your GitHub username in badge URLs to keep status badges working.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,8 @@
 The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes.
 Use `--months-per-row` to control the grid width, `--stl` to specify an STL
 output path, and `--colors` to split blocks into up to four color groups.
-[`viewer.html`](viewer.html) previews the resulting STLs in the browser with Three.js.
+[`viewer.html`](viewer.html) previews the resulting STLs in the browser with
+[Three.js](https://threejs.org/).
 
 ## Prompts
 


### PR DESCRIPTION
## Summary
- update README to use current personal access token URL
- link Three.js in README and docs index

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92db87a7c832f90f9985f6864e33a