### PR TITLE
📝 docs: clarify months-per-row usage and link design spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ python -m gitshelves.cli <github-username> \
     --months-per-row 10 --stl contributions.stl --colors 1
 ```
 
-The command will create `contributions.scad` (and optionally `contributions.stl`) in the current directory. Months are arranged in rows of twelve by default, but you can choose the grid width via `--months-per-row`.
+The command will create `contributions.scad` (and optionally `contributions.stl`) in the current directory. The example sets `--months-per-row 10`; omit this flag to keep the default of 12 months per row.
 
 For instance, `--months-per-row 8` lays out eight months per row:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,10 @@ output path, and `--colors` to split blocks into up to four color groups.
 - [Codex automation prompt](prompts-codex.md) – baseline instructions for automated agents.
 - [Codex spellcheck prompt](prompts-codex-spellcheck.md) – fix typos in docs.
 
+## Design
+
+- [Gridfinity design specification](gridfinity_design.md) – baseplate and cube dimensions.
+
 ## Spellcheck
 
 Run `codespell` to catch typos. Project-specific words such as Gitshelves,


### PR DESCRIPTION
## What
- clarify default grid width in README
- link design specification from docs index

## Why
- improve documentation clarity and navigation

## How to test
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92db87a7c832f90f9985f6864e33a