### PR TITLE
🐛 Fix singular contribution wording

### DIFF
--- a/gitshelves/readme.py
+++ b/gitshelves/readme.py
@@ -32,7 +32,7 @@ def write_year_readme(
         cubes = blocks_for_contributions(count)
         name = datetime(year, month, 1).strftime("%B")
         lines.append(
-            f"- {name}: {count} contributions \u2192 {cubes} cube{'s' if cubes != 1 else ''}"
+            f"- {name}: {count} contribution{'s' if count != 1 else ''} \u2192 {cubes} cube{'s' if cubes != 1 else ''}"
         )
 
     lines += [

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -13,6 +13,6 @@ def test_write_year_readme_zero_and_plural(tmp_path):
     counts = {(2024, 1): 1, (2024, 2): 10}
     readme = write_year_readme(2024, counts, outdir=tmp_path)
     text = readme.read_text()
-    assert "January: 1 contributions \u2192 1 cube" in text
+    assert "January: 1 contribution \u2192 1 cube" in text
     assert "February: 10 contributions \u2192 2 cubes" in text
     assert "March: 0 contributions \u2192 0 cubes" in text


### PR DESCRIPTION
## Summary
- ensure yearly README uses singular *contribution* when count is one
- update tests for proper grammar

## Testing
- `black --check .`
- `pytest -q`
- `pytest --cov=gitshelves --cov-report=term -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92db17ef0832f9931d53451703c6c