### PR TITLE
docs: fix block file wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Jan Feb Mar Apr May Jun Jul Aug
 Sep Oct Nov Dec
 ```
 
-Use `--colors` to control multi-color outputs. `--colors 2` produces one blocks file and a baseplate for two-color prints. `--colors 3` or `4` group logarithmic levels into additional color files. Each `*_colorN.scad` (`*_colorN.stl`) contains the blocks for a color group.
+Use `--colors` to control multi-color outputs. `--colors 2` produces one block file and a baseplate for two-color prints. `--colors 3` or `4` group logarithmic levels into additional color files. Each `*_colorN.scad` (`*_colorN.stl`) contains the blocks for a color group.
 
 Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with
 Three.js and experiment with different color counts.


### PR DESCRIPTION
## Summary
- fix minor wording in README to refer to a single block file

## Testing
- `codespell --ignore-words dict/allow.txt docs README.md`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92dbee894832f9460f67a4b41f4a9