### PR TITLE
Replace deprecated utcnow usage

### DIFF
--- a/gitshelves/fetch.py
+++ b/gitshelves/fetch.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Dict, Iterable, List
 
 import requests
@@ -11,7 +11,7 @@ def _determine_year_range(
     start_year: int | None, end_year: int | None
 ) -> tuple[int, int]:
     """Return inclusive start and end years, validating user input."""
-    end = datetime.utcnow().year if end_year is None else end_year
+    end = datetime.now(UTC).year if end_year is None else end_year
     start = end if start_year is None else start_year
     if start > end:
         raise ValueError("start_year cannot be after end_year")

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -59,8 +59,12 @@ def test_fetch_multiple_pages_with_token(monkeypatch):
 
     class DummyDateTime(datetime):
         @classmethod
-        def utcnow(cls):
-            return datetime(2021, 1, 1)
+        def now(cls, tz=None):
+            return datetime(2021, 1, 1, tzinfo=tz)
+
+        @classmethod
+        def utcnow(cls):  # pragma: no cover - should not be called
+            raise AssertionError("utcnow should not be used")
 
     monkeypatch.setattr(fetch, "datetime", DummyDateTime)
     monkeypatch.setattr(fetch.requests, "get", fake_get)


### PR DESCRIPTION
## Summary
- use datetime.now(UTC) to derive current year
- update tests to patch datetime.now and flag utcnow usage

## Testing
- black --check .
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68aa9c567bc8832fb73d67e54f802b91