### PR TITLE
Add edge-case tests for fetch and SCAD utilities

### DIFF
--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -110,3 +110,18 @@ def test_fetch_user_contributions_rejects_invalid_year_range(monkeypatch):
 
     with pytest.raises(ValueError):
         fetch.fetch_user_contributions("me", start_year=2025, end_year=2024)
+
+
+def test_determine_year_range_defaults(monkeypatch):
+    """Defaults should fall back to the current year."""
+
+    class DummyDateTime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return datetime(2022, 6, 1)
+
+    monkeypatch.setattr(fetch, "datetime", DummyDateTime)
+
+    assert fetch._determine_year_range(None, None) == (2022, 2022)
+    assert fetch._determine_year_range(None, 2021) == (2021, 2021)
+    assert fetch._determine_year_range(2020, None) == (2020, 2022)

--- a/tests/test_scad.py
+++ b/tests/test_scad.py
@@ -54,6 +54,15 @@ def test_iter_monthly_block_positions_empty():
     assert list(_iter_monthly_block_positions({}, 12)) == []
 
 
+def test_iter_monthly_block_positions_requires_positive_months_per_row():
+    """months_per_row must be a positive integer."""
+
+    with pytest.raises(ValueError):
+        list(_iter_monthly_block_positions({(2021, 1): 1}, 0))
+    with pytest.raises(ValueError):
+        list(_iter_monthly_block_positions({(2021, 1): 1}, -2))
+
+
 def test_generate_scad_monthly_levels():
     counts = {
         (2021, 1): 1,


### PR DESCRIPTION
## Summary
- test default year range handling
- ensure month grouping rejects non-positive values

## Testing
- `pip install -e .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ce5ff98832f81e4a2ebf9546621