### PR TITLE
📝: clarify year range defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Gitshelves fetches GitHub contribution data and turns it into 3D printable model
    `GITHUB_TOKEN` if `--token` is omitted.
    `fetch_user_contributions` likewise falls back to these variables when
    no token argument is supplied.
+   Without `--start-year` and `--end-year`, only the current year's
+   contributions are included.
 
 ```bash
 pip install -e .

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@ For setup and usage details, see the [README](../README.md).
 The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes.
 Use `--months-per-row` to control the grid width, `--stl` to specify an STL
 output path, and `--colors` to split blocks into up to four color groups.
+By default, the current year's contributions are fetched unless
+`--start-year` and `--end-year` specify a range.
 [`viewer.html`](viewer.html) previews the resulting STLs in the browser with
 [Three.js](https://threejs.org/).
 


### PR DESCRIPTION
## Summary
- document that current year is used when --start-year and --end-year are omitted
- note default year handling in docs index

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ca69f7c832faa79f26643c459fe