### PR TITLE
📝 : clarify token env var in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Gitshelves fetches GitHub contribution data and turns it into 3D printable model
 ## Usage
 
 1. Install the package in editable mode.
-2. Generate a [personal access token](https://github.com/settings/personal-access-tokens/new)
-   and export it as `GH_TOKEN`.
+2. Generate a [personal access token](https://github.com/settings/tokens/new) and export it as
+   `GH_TOKEN` or `GITHUB_TOKEN`.
 3. Run the CLI to generate a `.scad` file. The token is read from `GH_TOKEN` or
    `GITHUB_TOKEN` if `--token` is omitted.
    `fetch_user_contributions` likewise falls back to these variables when


### PR DESCRIPTION
## Summary
- clarify that either GH_TOKEN or GITHUB_TOKEN can be used
- update PAT link to current GitHub settings

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ca69f7c832faa79f26643c459fe