### PR TITLE
📝: document --output flag for custom SCAD names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ python -m gitshelves.cli <github-username> \
     --months-per-row 10 --stl contributions.stl --colors 1
 ```
 
-The command will create `contributions.scad` (and optionally `contributions.stl`) in the current directory. The example sets `--months-per-row 10`; omit this flag to keep the default of 12 months per row.
+The command creates `contributions.scad` (and optionally `contributions.stl`)
+in the current directory. The example sets `--months-per-row 10`; omit this
+flag to keep the default of 12 months per row. Use `--output` to pick a
+different `.scad` filename.
 
 For instance, `--months-per-row 8` lays out eight months per row:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,10 +3,10 @@
 For setup and usage details, see the [README](../README.md).
 
 The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes.
-Use `--months-per-row` to control the grid width, `--stl` to specify an STL
-output path, and `--colors` to split blocks into up to four color groups.
-[`viewer.html`](viewer.html) previews the resulting STLs in the browser with
-[Three.js](https://threejs.org/).
+Use `--output` to change the `.scad` filename, `--months-per-row` to control the
+grid width, `--stl` to specify an STL output path, and `--colors` to split
+blocks into up to four color groups. [`viewer.html`](viewer.html) previews the
+resulting STLs in the browser with [Three.js](https://threejs.org/).
 
 ## Prompts
 


### PR DESCRIPTION
what: note --output flag in README and docs index
why: clarify how to rename generated SCAD files
how to test: black --check . && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa9ca69f7c832faa79f26643c459fe