### PR TITLE
Add CLI version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Jan Feb Mar Apr May Jun Jul Aug
 Sep Oct Nov Dec
 ```
 
+Print the current version with:
+
+```bash
+python -m gitshelves.cli --version
+```
+
 Use `--colors` to control multi-color outputs. `--colors 2` produces one block file and a baseplate for two-color prints. `--colors 3` or `4` group logarithmic levels into additional color files. Each `*_colorN.scad` (`*_colorN.stl`) contains the blocks for a color group.
 
 Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with

--- a/gitshelves/__init__.py
+++ b/gitshelves/__init__.py
@@ -1,11 +1,19 @@
 """Utilities for generating 3D printable GitHub contribution charts."""
 
+from importlib import metadata
+
 from .scad import generate_scad, generate_scad_monthly, blocks_for_contributions
 from .fetch import fetch_user_contributions
+
+try:  # pragma: no cover - handled in package distribution
+    __version__ = metadata.version("gitshelves")
+except metadata.PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"
 
 __all__ = [
     "generate_scad",
     "generate_scad_monthly",
     "blocks_for_contributions",
     "fetch_user_contributions",
+    "__version__",
 ]

--- a/gitshelves/cli.py
+++ b/gitshelves/cli.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from pathlib import Path
 from datetime import datetime
+from importlib import metadata
 
 from .fetch import fetch_user_contributions
 from .scad import (
@@ -13,7 +14,7 @@ from .scad import (
 from .readme import write_year_readme
 
 
-def main():
+def main(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(
         description="Generate 3D GitHub contribution charts"
     )
@@ -44,7 +45,14 @@ def main():
         default=1,
         help="Number of print colors (1-4)",
     )
-    args = parser.parse_args()
+    try:  # pragma: no cover - metadata lookup
+        pkg_version = metadata.version("gitshelves")
+    except metadata.PackageNotFoundError:  # pragma: no cover
+        pkg_version = "0.0.0"
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {pkg_version}"
+    )
+    args = parser.parse_args(argv)
 
     token = args.token or os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
     contribs = fetch_user_contributions(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 import argparse
 from pathlib import Path
 
+import pytest
 import gitshelves.cli as cli
+import gitshelves
 
 
 def test_cli_main(tmp_path, monkeypatch, capsys):
@@ -32,7 +34,9 @@ def test_cli_main(tmp_path, monkeypatch, capsys):
         colors=1,
     )
 
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(
+        argparse.ArgumentParser, "parse_args", lambda self, *a, **k: args
+    )
     monkeypatch.setattr(cli, "fetch_user_contributions", fake_fetch)
     called = {}
     monkeypatch.setattr(cli, "generate_scad_monthly", fake_generate)
@@ -63,7 +67,9 @@ def test_cli_creates_output_dirs(tmp_path, monkeypatch):
         stl=str(tmp_path / "nested" / "dir" / "out.stl"),
         colors=1,
     )
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(
+        argparse.ArgumentParser, "parse_args", lambda self, *a, **k: args
+    )
     monkeypatch.setattr(
         cli,
         "fetch_user_contributions",
@@ -100,7 +106,9 @@ def test_cli_env_token(tmp_path, monkeypatch):
     )
 
     monkeypatch.setenv("GH_TOKEN", "envtok")
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(
+        argparse.ArgumentParser, "parse_args", lambda self, *a, **k: args
+    )
 
     captured = {}
 
@@ -135,7 +143,9 @@ def test_cli_github_token_env(tmp_path, monkeypatch):
 
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setenv("GITHUB_TOKEN", "envtok2")
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(
+        argparse.ArgumentParser, "parse_args", lambda self, *a, **k: args
+    )
 
     captured = {}
 
@@ -168,7 +178,9 @@ def test_cli_runpy(tmp_path, monkeypatch):
         colors=1,
     )
 
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(
+        argparse.ArgumentParser, "parse_args", lambda self, *a, **k: args
+    )
 
     import sys, types, runpy
 
@@ -212,7 +224,9 @@ def test_cli_multiple_colors(tmp_path, monkeypatch, capsys):
         stl=str(tmp_path / "c.stl"),
         colors=3,
     )
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(
+        argparse.ArgumentParser, "parse_args", lambda self, *a, **k: args
+    )
 
     def fake_fetch(username, token=None, start_year=None, end_year=None):
         return [{"created_at": "2021-02-01T00:00:00Z"}]
@@ -247,6 +261,13 @@ def test_cli_multiple_colors(tmp_path, monkeypatch, capsys):
     assert called == [(str(scad1), str(stl1)), (str(scad2), str(stl2))]
     captured = capsys.readouterr()
     assert f"Wrote {scad1}" in captured.out
+
+
+def test_cli_version(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["--version"])
+    out = capsys.readouterr().out.strip()
+    assert gitshelves.__version__ in out
 
 
 def test_cli_help_mentions_env_vars():


### PR DESCRIPTION
## Summary
- expose `__version__` via importlib metadata
- add `--version` option to CLI and document usage
- test CLI `--version`

## Testing
- `codespell docs README.md`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9c3ee5b4832f933f4032282adef1