### PR TITLE
🐛: remove utcnow deprecation

### DIFF
--- a/gitshelves/fetch.py
+++ b/gitshelves/fetch.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Iterable, List
 
 import requests
@@ -11,7 +11,7 @@ def _determine_year_range(
     start_year: int | None, end_year: int | None
 ) -> tuple[int, int]:
     """Return inclusive start and end years, validating user input."""
-    end = datetime.utcnow().year if end_year is None else end_year
+    end = datetime.now(timezone.utc).year if end_year is None else end_year
     start = end if start_year is None else start_year
     if start > end:
         raise ValueError("start_year cannot be after end_year")


### PR DESCRIPTION
## Summary
- use timezone-aware datetime when computing year range
- test timezone-aware call
- verify default year range falls back to current UTC year
- compare timezone constant directly in tests

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9c14a0cc832fa8514047cd230b64