### PR TITLE
🪚 : add wall shelf CAD and STL with drywall mounting holes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - `.github/workflows/build-stl.yml` runs on pushes and pull requests to `main`, removes any existing Gridfinity library folder, clones the library, installs OpenSCAD and Xvfb via `apt`, renders `openscad/baseplate_2x6.scad` to `stl/<year>/baseplate_2x6.stl` using `xvfb-run`, and uploads them as workflow artifacts
 - `scad_to_stl` wraps `openscad` in `xvfb-run` automatically when `$DISPLAY` is missing to mirror the CI workflow
 - `openscad/lib/gridfinity-rebuilt/` holds the Gridfinity library (MIT). CI clones it automatically; clone it manually for local builds and keep the `LICENSE` file. We consult vector76/gridfinity_openscad for guidance
+- `openscad/shelf.scad` and its pre-rendered `stl/shelf.stl` define a basic wall shelf with drywall mounting holes
 - `--colors` controls multi-color output, grouping logarithmic levels into up to four block colors
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Gitshelves fetches GitHub contribution data and turns it into 3D printable models. Each month of activity becomes a stack of blocks whose height is determined logarithmically by the number of contributions. The models are exported as `.scad` files for OpenSCAD and can be previewed with Three.js.
 
+A simple wall shelf with drywall mounting holes lives in `openscad/shelf.scad`. Use the pre-rendered `stl/shelf.stl` to print a matching display shelf for your contribution charts.
+
 ## Usage
 
 1. Install the package in editable mode.

--- a/openscad/shelf.scad
+++ b/openscad/shelf.scad
@@ -1,0 +1,27 @@
+// Simple shelf with drywall mounting holes
+// dimensions in millimeters
+
+length = 180;
+depth = 80;
+thickness = 15;
+
+hole_d = 5;
+head_d = 9;
+head_depth = 3;
+offset = 20;
+
+module shelf() {
+    difference() {
+        cube([length, depth, thickness]);
+        for (x = [offset, length - offset])
+            translate([x, 0, thickness / 2])
+                rotate([-90, 0, 0])
+                    cylinder(h = depth, d = hole_d);
+        for (x = [offset, length - offset])
+            translate([x, 0, thickness / 2])
+                rotate([-90, 0, 0])
+                    cylinder(h = head_depth, d = head_d);
+    }
+}
+
+shelf();

--- a/stl/shelf.stl
+++ b/stl/shelf.stl
@@ -1,0 +1,1430 @@
+solid OpenSCAD_Model
+  facet normal -0.382676 0 0.923883
+    outer loop
+      vertex 20 80 5
+      vertex 21.7678 3 5.73223
+      vertex 21.7678 80 5.73223
+    endloop
+  endfacet
+  facet normal -0.382676 0 0.923883
+    outer loop
+      vertex 21.7678 3 5.73223
+      vertex 20 80 5
+      vertex 20 3 5
+    endloop
+  endfacet
+  facet normal -0.923886 0 0.382668
+    outer loop
+      vertex 21.7678 3 5.73223
+      vertex 22.5 80 7.5
+      vertex 21.7678 80 5.73223
+    endloop
+  endfacet
+  facet normal -0.923886 0 0.382668
+    outer loop
+      vertex 22.5 80 7.5
+      vertex 21.7678 3 5.73223
+      vertex 22.5 3 7.5
+    endloop
+  endfacet
+  facet normal 0.382676 0 0.923883
+    outer loop
+      vertex 18.2322 80 5.73223
+      vertex 20 3 5
+      vertex 20 80 5
+    endloop
+  endfacet
+  facet normal 0.382676 0 0.923883
+    outer loop
+      vertex 20 3 5
+      vertex 18.2322 80 5.73223
+      vertex 18.2322 3 5.73223
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 158.232 80 9.26777
+      vertex 20 80 10
+      vertex 160 80 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 158.232 80 9.26777
+      vertex 21.7678 80 9.26777
+      vertex 20 80 10
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 157.5 80 7.5
+      vertex 21.7678 80 9.26777
+      vertex 158.232 80 9.26777
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 157.5 80 7.5
+      vertex 22.5 80 7.5
+      vertex 21.7678 80 9.26777
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 158.232 80 5.73223
+      vertex 22.5 80 7.5
+      vertex 157.5 80 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 158.232 80 5.73223
+      vertex 21.7678 80 5.73223
+      vertex 22.5 80 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 160 80 5
+      vertex 21.7678 80 5.73223
+      vertex 158.232 80 5.73223
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.7678 80 5.73223
+      vertex 160 80 5
+      vertex 20 80 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 180 80 15
+      vertex 160 80 10
+      vertex 0 80 15
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 180 80 15
+      vertex 161.768 80 9.26777
+      vertex 160 80 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 180 80 15
+      vertex 162.5 80 7.5
+      vertex 161.768 80 9.26777
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 180 80 0
+      vertex 162.5 80 7.5
+      vertex 180 80 15
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 160 80 5
+      vertex 180 80 0
+      vertex 20 80 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 161.768 80 5.73223
+      vertex 180 80 0
+      vertex 160 80 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 162.5 80 7.5
+      vertex 180 80 0
+      vertex 161.768 80 5.73223
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20 80 10
+      vertex 0 80 15
+      vertex 160 80 10
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.2322 80 9.26777
+      vertex 0 80 15
+      vertex 20 80 10
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.5 80 7.5
+      vertex 0 80 15
+      vertex 18.2322 80 9.26777
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 80 0
+      vertex 17.5 80 7.5
+      vertex 18.2322 80 5.73223
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.5 80 7.5
+      vertex 0 80 0
+      vertex 0 80 15
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20 80 5
+      vertex 0 80 0
+      vertex 18.2322 80 5.73223
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 80 0
+      vertex 20 80 5
+      vertex 180 80 0
+    endloop
+  endfacet
+  facet normal -0.923886 0 -0.382668
+    outer loop
+      vertex 22.5 3 7.5
+      vertex 21.7678 80 9.26777
+      vertex 22.5 80 7.5
+    endloop
+  endfacet
+  facet normal -0.923886 -0 -0.382668
+    outer loop
+      vertex 21.7678 80 9.26777
+      vertex 22.5 3 7.5
+      vertex 21.7678 3 9.26777
+    endloop
+  endfacet
+  facet normal 0.923886 -0 0.382668
+    outer loop
+      vertex 17.5 3 7.5
+      vertex 18.2322 80 5.73223
+      vertex 17.5 80 7.5
+    endloop
+  endfacet
+  facet normal 0.923886 0 0.382668
+    outer loop
+      vertex 18.2322 80 5.73223
+      vertex 17.5 3 7.5
+      vertex 18.2322 3 5.73223
+    endloop
+  endfacet
+  facet normal 0.382676 0 -0.923883
+    outer loop
+      vertex 18.2322 3 9.26777
+      vertex 20 80 10
+      vertex 20 3 10
+    endloop
+  endfacet
+  facet normal 0.382676 0 -0.923883
+    outer loop
+      vertex 20 80 10
+      vertex 18.2322 3 9.26777
+      vertex 18.2322 80 9.26777
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 180 0 15
+      vertex 21.3906 0 11.7798
+      vertex 159.53 0 11.9753
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.3906 0 11.7798
+      vertex 157.75 0 11.3971
+      vertex 159.53 0 11.9753
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.0111 0 10.8442
+      vertex 157.75 0 11.3971
+      vertex 21.3906 0 11.7798
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.0111 0 10.8442
+      vertex 156.359 0 10.145
+      vertex 157.75 0 11.3971
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 24.111 0 9.33031
+      vertex 156.359 0 10.145
+      vertex 23.0111 0 10.8442
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 24.111 0 9.33031
+      vertex 155.598 0 8.4356
+      vertex 156.359 0 10.145
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 24.5 0 7.5
+      vertex 155.598 0 8.4356
+      vertex 24.111 0 9.33031
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 24.5 0 7.5
+      vertex 155.598 0 6.5644
+      vertex 155.598 0 8.4356
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 24.111 0 5.66968
+      vertex 155.598 0 6.5644
+      vertex 24.5 0 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 24.111 0 5.66968
+      vertex 156.359 0 4.85497
+      vertex 155.598 0 6.5644
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.0111 0 4.15585
+      vertex 156.359 0 4.85497
+      vertex 24.111 0 5.66968
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.0111 0 4.15585
+      vertex 157.75 0 3.60289
+      vertex 156.359 0 4.85497
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.3906 0 3.22025
+      vertex 157.75 0 3.60289
+      vertex 23.0111 0 4.15585
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 21.3906 0 3.22025
+      vertex 19.5296 0 3.02465
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.3906 0 3.22025
+      vertex 159.53 0 3.02465
+      vertex 157.75 0 3.60289
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.3906 0 11.7798
+      vertex 0 0 15
+      vertex 19.5296 0 11.9753
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 15
+      vertex 17.75 0 11.3971
+      vertex 19.5296 0 11.9753
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 15
+      vertex 16.3594 0 10.145
+      vertex 17.75 0 11.3971
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 15
+      vertex 15.5983 0 8.4356
+      vertex 16.3594 0 10.145
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 15
+      vertex 15.5983 0 6.5644
+      vertex 15.5983 0 8.4356
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 15.5983 0 6.5644
+      vertex 0 0 15
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 15.5983 0 6.5644
+      vertex 0 0 0
+      vertex 16.3594 0 4.85497
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 21.3906 0 3.22025
+      vertex 0 0 0
+      vertex 159.53 0 3.02465
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 17.75 0 3.60289
+      vertex 0 0 0
+      vertex 19.5296 0 3.02465
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 16.3594 0 4.85497
+      vertex 0 0 0
+      vertex 17.75 0 3.60289
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 15
+      vertex 21.3906 0 11.7798
+      vertex 180 0 15
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 161.391 0 11.7798
+      vertex 180 0 15
+      vertex 159.53 0 11.9753
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 163.011 0 10.8442
+      vertex 180 0 15
+      vertex 161.391 0 11.7798
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 164.111 0 9.33031
+      vertex 180 0 15
+      vertex 163.011 0 10.8442
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 164.5 0 7.5
+      vertex 180 0 15
+      vertex 164.111 0 9.33031
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 180 0 0
+      vertex 164.5 0 7.5
+      vertex 164.111 0 5.66968
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 180 0 0
+      vertex 164.111 0 5.66968
+      vertex 163.011 0 4.15585
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 164.5 0 7.5
+      vertex 180 0 0
+      vertex 180 0 15
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 161.391 0 3.22025
+      vertex 180 0 0
+      vertex 163.011 0 4.15585
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 159.53 0 3.02465
+      vertex 180 0 0
+      vertex 161.391 0 3.22025
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 180 0 0
+      vertex 159.53 0 3.02465
+      vertex 0 0 0
+    endloop
+  endfacet
+  facet normal -0.382676 0 -0.923883
+    outer loop
+      vertex 20 3 10
+      vertex 21.7678 80 9.26777
+      vertex 21.7678 3 9.26777
+    endloop
+  endfacet
+  facet normal -0.382676 0 -0.923883
+    outer loop
+      vertex 21.7678 80 9.26777
+      vertex 20 3 10
+      vertex 20 80 10
+    endloop
+  endfacet
+  facet normal 0.923886 0 -0.382668
+    outer loop
+      vertex 18.2322 3 9.26777
+      vertex 17.5 80 7.5
+      vertex 18.2322 80 9.26777
+    endloop
+  endfacet
+  facet normal 0.923886 0 -0.382668
+    outer loop
+      vertex 17.5 80 7.5
+      vertex 18.2322 3 9.26777
+      vertex 17.5 3 7.5
+    endloop
+  endfacet
+  facet normal -0.382639 0 0.923898
+    outer loop
+      vertex 160 80 5
+      vertex 161.768 3 5.73223
+      vertex 161.768 80 5.73223
+    endloop
+  endfacet
+  facet normal -0.382639 0 0.923898
+    outer loop
+      vertex 161.768 3 5.73223
+      vertex 160 80 5
+      vertex 160 3 5
+    endloop
+  endfacet
+  facet normal -0.923923 0 0.382579
+    outer loop
+      vertex 161.768 3 5.73223
+      vertex 162.5 80 7.5
+      vertex 161.768 80 5.73223
+    endloop
+  endfacet
+  facet normal -0.923923 0 0.382579
+    outer loop
+      vertex 162.5 80 7.5
+      vertex 161.768 3 5.73223
+      vertex 162.5 3 7.5
+    endloop
+  endfacet
+  facet normal 0.382639 0 0.923898
+    outer loop
+      vertex 158.232 80 5.73223
+      vertex 160 3 5
+      vertex 160 80 5
+    endloop
+  endfacet
+  facet normal 0.382639 0 0.923898
+    outer loop
+      vertex 160 3 5
+      vertex 158.232 80 5.73223
+      vertex 158.232 3 5.73223
+    endloop
+  endfacet
+  facet normal -0.923923 0 -0.382579
+    outer loop
+      vertex 162.5 3 7.5
+      vertex 161.768 80 9.26777
+      vertex 162.5 80 7.5
+    endloop
+  endfacet
+  facet normal -0.923923 -0 -0.382579
+    outer loop
+      vertex 161.768 80 9.26777
+      vertex 162.5 3 7.5
+      vertex 161.768 3 9.26777
+    endloop
+  endfacet
+  facet normal 0.923923 -0 0.382579
+    outer loop
+      vertex 157.5 3 7.5
+      vertex 158.232 80 5.73223
+      vertex 157.5 80 7.5
+    endloop
+  endfacet
+  facet normal 0.923923 0 0.382579
+    outer loop
+      vertex 158.232 80 5.73223
+      vertex 157.5 3 7.5
+      vertex 158.232 3 5.73223
+    endloop
+  endfacet
+  facet normal 0.382639 0 -0.923898
+    outer loop
+      vertex 158.232 3 9.26777
+      vertex 160 80 10
+      vertex 160 3 10
+    endloop
+  endfacet
+  facet normal 0.382639 0 -0.923898
+    outer loop
+      vertex 160 80 10
+      vertex 158.232 3 9.26777
+      vertex 158.232 80 9.26777
+    endloop
+  endfacet
+  facet normal -0.382639 0 -0.923898
+    outer loop
+      vertex 160 3 10
+      vertex 161.768 80 9.26777
+      vertex 161.768 3 9.26777
+    endloop
+  endfacet
+  facet normal -0.382639 0 -0.923898
+    outer loop
+      vertex 161.768 80 9.26777
+      vertex 160 3 10
+      vertex 160 80 10
+    endloop
+  endfacet
+  facet normal 0.923923 0 -0.382579
+    outer loop
+      vertex 158.232 3 9.26777
+      vertex 157.5 80 7.5
+      vertex 158.232 80 9.26777
+    endloop
+  endfacet
+  facet normal 0.923923 0 -0.382579
+    outer loop
+      vertex 157.5 80 7.5
+      vertex 158.232 3 9.26777
+      vertex 157.5 3 7.5
+    endloop
+  endfacet
+  facet normal -0.500002 0 0.866025
+    outer loop
+      vertex 21.3906 3 3.22025
+      vertex 23.0111 0 4.15585
+      vertex 23.0111 3 4.15585
+    endloop
+  endfacet
+  facet normal -0.500002 0 0.866025
+    outer loop
+      vertex 23.0111 0 4.15585
+      vertex 21.3906 3 3.22025
+      vertex 21.3906 0 3.22025
+    endloop
+  endfacet
+  facet normal 0.91354 0 -0.406748
+    outer loop
+      vertex 16.3594 0 10.145
+      vertex 15.5983 3 8.4356
+      vertex 16.3594 3 10.145
+    endloop
+  endfacet
+  facet normal 0.91354 0 -0.406748
+    outer loop
+      vertex 15.5983 3 8.4356
+      vertex 16.3594 0 10.145
+      vertex 15.5983 0 8.4356
+    endloop
+  endfacet
+  facet normal -0.809007 0 0.587799
+    outer loop
+      vertex 23.0111 0 4.15585
+      vertex 24.111 3 5.66968
+      vertex 23.0111 3 4.15585
+    endloop
+  endfacet
+  facet normal -0.809007 0 0.587799
+    outer loop
+      vertex 24.111 3 5.66968
+      vertex 23.0111 0 4.15585
+      vertex 24.111 0 5.66968
+    endloop
+  endfacet
+  facet normal -0.978153 0 0.207888
+    outer loop
+      vertex 24.111 0 5.66968
+      vertex 24.5 3 7.5
+      vertex 24.111 3 5.66968
+    endloop
+  endfacet
+  facet normal -0.978153 0 0.207888
+    outer loop
+      vertex 24.5 3 7.5
+      vertex 24.111 0 5.66968
+      vertex 24.5 0 7.5
+    endloop
+  endfacet
+  facet normal -0.978152 0 -0.207889
+    outer loop
+      vertex 24.5 0 7.5
+      vertex 24.111 3 9.33031
+      vertex 24.5 3 7.5
+    endloop
+  endfacet
+  facet normal -0.978152 -0 -0.207889
+    outer loop
+      vertex 24.111 3 9.33031
+      vertex 24.5 0 7.5
+      vertex 24.111 0 9.33031
+    endloop
+  endfacet
+  facet normal 0.913543 -0 0.406742
+    outer loop
+      vertex 15.5983 0 6.5644
+      vertex 16.3594 3 4.85497
+      vertex 15.5983 3 6.5644
+    endloop
+  endfacet
+  facet normal 0.913543 0 0.406742
+    outer loop
+      vertex 16.3594 3 4.85497
+      vertex 15.5983 0 6.5644
+      vertex 16.3594 0 4.85497
+    endloop
+  endfacet
+  facet normal 0.669124 0 0.743151
+    outer loop
+      vertex 16.3594 3 4.85497
+      vertex 17.75 0 3.60289
+      vertex 17.75 3 3.60289
+    endloop
+  endfacet
+  facet normal 0.669124 0 0.743151
+    outer loop
+      vertex 17.75 0 3.60289
+      vertex 16.3594 3 4.85497
+      vertex 16.3594 0 4.85497
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.75 3 11.3971
+      vertex 18.2322 3 9.26777
+      vertex 20 3 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.5983 3 8.4356
+      vertex 18.2322 3 9.26777
+      vertex 16.3594 3 10.145
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.5983 3 8.4356
+      vertex 17.5 3 7.5
+      vertex 18.2322 3 9.26777
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.5983 3 6.5644
+      vertex 17.5 3 7.5
+      vertex 15.5983 3 8.4356
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.5983 3 6.5644
+      vertex 18.2322 3 5.73223
+      vertex 17.5 3 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 16.3594 3 4.85497
+      vertex 18.2322 3 5.73223
+      vertex 15.5983 3 6.5644
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 17.75 3 3.60289
+      vertex 18.2322 3 5.73223
+      vertex 16.3594 3 4.85497
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 20 3 10
+      vertex 19.5296 3 11.9753
+      vertex 17.75 3 11.3971
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 19.5296 3 11.9753
+      vertex 20 3 10
+      vertex 21.3906 3 11.7798
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 18.2322 3 9.26777
+      vertex 17.75 3 11.3971
+      vertex 16.3594 3 10.145
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.7678 3 9.26777
+      vertex 21.3906 3 11.7798
+      vertex 20 3 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.3906 3 11.7798
+      vertex 21.7678 3 9.26777
+      vertex 23.0111 3 10.8442
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 23.0111 3 10.8442
+      vertex 21.7678 3 9.26777
+      vertex 24.111 3 9.33031
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 22.5 3 7.5
+      vertex 24.111 3 9.33031
+      vertex 21.7678 3 9.26777
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 22.5 3 7.5
+      vertex 24.5 3 7.5
+      vertex 24.111 3 9.33031
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 24.111 3 5.66968
+      vertex 22.5 3 7.5
+      vertex 21.7678 3 5.73223
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 22.5 3 7.5
+      vertex 24.111 3 5.66968
+      vertex 24.5 3 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.3906 3 3.22025
+      vertex 21.7678 3 5.73223
+      vertex 20 3 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 21.7678 3 5.73223
+      vertex 23.0111 3 4.15585
+      vertex 24.111 3 5.66968
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18.2322 3 5.73223
+      vertex 17.75 3 3.60289
+      vertex 20 3 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 19.5296 3 3.02465
+      vertex 20 3 5
+      vertex 17.75 3 3.60289
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 21.7678 3 5.73223
+      vertex 21.3906 3 3.22025
+      vertex 23.0111 3 4.15585
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 20 3 5
+      vertex 19.5296 3 3.02465
+      vertex 21.3906 3 3.22025
+    endloop
+  endfacet
+  facet normal -0.500002 0 -0.866025
+    outer loop
+      vertex 21.3906 0 11.7798
+      vertex 23.0111 3 10.8442
+      vertex 23.0111 0 10.8442
+    endloop
+  endfacet
+  facet normal -0.500002 0 -0.866025
+    outer loop
+      vertex 23.0111 3 10.8442
+      vertex 21.3906 0 11.7798
+      vertex 21.3906 3 11.7798
+    endloop
+  endfacet
+  facet normal -0.104529 0 0.994522
+    outer loop
+      vertex 19.5296 3 3.02465
+      vertex 21.3906 0 3.22025
+      vertex 21.3906 3 3.22025
+    endloop
+  endfacet
+  facet normal -0.104529 0 0.994522
+    outer loop
+      vertex 21.3906 0 3.22025
+      vertex 19.5296 3 3.02465
+      vertex 19.5296 0 3.02465
+    endloop
+  endfacet
+  facet normal -0.809018 0 -0.587783
+    outer loop
+      vertex 24.111 0 9.33031
+      vertex 23.0111 3 10.8442
+      vertex 24.111 3 9.33031
+    endloop
+  endfacet
+  facet normal -0.809018 -0 -0.587783
+    outer loop
+      vertex 23.0111 3 10.8442
+      vertex 24.111 0 9.33031
+      vertex 23.0111 0 10.8442
+    endloop
+  endfacet
+  facet normal -0.104476 0 -0.994527
+    outer loop
+      vertex 19.5296 0 11.9753
+      vertex 21.3906 3 11.7798
+      vertex 21.3906 0 11.7798
+    endloop
+  endfacet
+  facet normal -0.104476 0 -0.994527
+    outer loop
+      vertex 21.3906 3 11.7798
+      vertex 19.5296 0 11.9753
+      vertex 19.5296 3 11.9753
+    endloop
+  endfacet
+  facet normal 0.309023 0 0.951054
+    outer loop
+      vertex 17.75 3 3.60289
+      vertex 19.5296 0 3.02465
+      vertex 19.5296 3 3.02465
+    endloop
+  endfacet
+  facet normal 0.309023 0 0.951054
+    outer loop
+      vertex 19.5296 0 3.02465
+      vertex 17.75 3 3.60289
+      vertex 17.75 0 3.60289
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 15.5983 0 8.4356
+      vertex 15.5983 3 6.5644
+      vertex 15.5983 3 8.4356
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 15.5983 3 6.5644
+      vertex 15.5983 0 8.4356
+      vertex 15.5983 0 6.5644
+    endloop
+  endfacet
+  facet normal 0.66913 0 -0.743145
+    outer loop
+      vertex 16.3594 0 10.145
+      vertex 17.75 3 11.3971
+      vertex 17.75 0 11.3971
+    endloop
+  endfacet
+  facet normal 0.66913 0 -0.743145
+    outer loop
+      vertex 17.75 3 11.3971
+      vertex 16.3594 0 10.145
+      vertex 16.3594 3 10.145
+    endloop
+  endfacet
+  facet normal 0.309004 0 -0.951061
+    outer loop
+      vertex 17.75 0 11.3971
+      vertex 19.5296 3 11.9753
+      vertex 19.5296 0 11.9753
+    endloop
+  endfacet
+  facet normal 0.309004 0 -0.951061
+    outer loop
+      vertex 19.5296 3 11.9753
+      vertex 17.75 0 11.3971
+      vertex 17.75 3 11.3971
+    endloop
+  endfacet
+  facet normal -0.500117 0 0.865958
+    outer loop
+      vertex 161.391 3 3.22025
+      vertex 163.011 0 4.15585
+      vertex 163.011 3 4.15585
+    endloop
+  endfacet
+  facet normal -0.500117 0 0.865958
+    outer loop
+      vertex 163.011 0 4.15585
+      vertex 161.391 3 3.22025
+      vertex 161.391 0 3.22025
+    endloop
+  endfacet
+  facet normal 0.91356 0 -0.406704
+    outer loop
+      vertex 156.359 0 10.145
+      vertex 155.598 3 8.4356
+      vertex 156.359 3 10.145
+    endloop
+  endfacet
+  facet normal 0.91356 0 -0.406704
+    outer loop
+      vertex 155.598 3 8.4356
+      vertex 156.359 0 10.145
+      vertex 155.598 0 8.4356
+    endloop
+  endfacet
+  facet normal -0.808982 0 0.587834
+    outer loop
+      vertex 163.011 0 4.15585
+      vertex 164.111 3 5.66968
+      vertex 163.011 3 4.15585
+    endloop
+  endfacet
+  facet normal -0.808982 0 0.587834
+    outer loop
+      vertex 164.111 3 5.66968
+      vertex 163.011 0 4.15585
+      vertex 164.111 0 5.66968
+    endloop
+  endfacet
+  facet normal -0.978153 0 0.207888
+    outer loop
+      vertex 164.111 0 5.66968
+      vertex 164.5 3 7.5
+      vertex 164.111 3 5.66968
+    endloop
+  endfacet
+  facet normal -0.978153 0 0.207888
+    outer loop
+      vertex 164.5 3 7.5
+      vertex 164.111 0 5.66968
+      vertex 164.5 0 7.5
+    endloop
+  endfacet
+  facet normal -0.808993 0 -0.587818
+    outer loop
+      vertex 164.111 0 9.33031
+      vertex 163.011 3 10.8442
+      vertex 164.111 3 9.33031
+    endloop
+  endfacet
+  facet normal -0.808993 -0 -0.587818
+    outer loop
+      vertex 163.011 3 10.8442
+      vertex 164.111 0 9.33031
+      vertex 163.011 0 10.8442
+    endloop
+  endfacet
+  facet normal -0.978152 0 -0.207889
+    outer loop
+      vertex 164.5 0 7.5
+      vertex 164.111 3 9.33031
+      vertex 164.5 3 7.5
+    endloop
+  endfacet
+  facet normal -0.978152 -0 -0.207889
+    outer loop
+      vertex 164.111 3 9.33031
+      vertex 164.5 0 7.5
+      vertex 164.111 0 9.33031
+    endloop
+  endfacet
+  facet normal 0.913563 -0 0.406698
+    outer loop
+      vertex 155.598 0 6.5644
+      vertex 156.359 3 4.85497
+      vertex 155.598 3 6.5644
+    endloop
+  endfacet
+  facet normal 0.913563 0 0.406698
+    outer loop
+      vertex 156.359 3 4.85497
+      vertex 155.598 0 6.5644
+      vertex 156.359 0 4.85497
+    endloop
+  endfacet
+  facet normal 0.669018 0 0.743246
+    outer loop
+      vertex 156.359 3 4.85497
+      vertex 157.75 0 3.60289
+      vertex 157.75 3 3.60289
+    endloop
+  endfacet
+  facet normal 0.669018 0 0.743246
+    outer loop
+      vertex 157.75 0 3.60289
+      vertex 156.359 3 4.85497
+      vertex 156.359 0 4.85497
+    endloop
+  endfacet
+  facet normal -0.500117 0 -0.865958
+    outer loop
+      vertex 161.391 0 11.7798
+      vertex 163.011 3 10.8442
+      vertex 163.011 0 10.8442
+    endloop
+  endfacet
+  facet normal -0.500117 0 -0.865958
+    outer loop
+      vertex 163.011 3 10.8442
+      vertex 161.391 0 11.7798
+      vertex 161.391 3 11.7798
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 157.75 3 11.3971
+      vertex 158.232 3 9.26777
+      vertex 160 3 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 155.598 3 8.4356
+      vertex 158.232 3 9.26777
+      vertex 156.359 3 10.145
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 155.598 3 8.4356
+      vertex 157.5 3 7.5
+      vertex 158.232 3 9.26777
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 155.598 3 6.5644
+      vertex 157.5 3 7.5
+      vertex 155.598 3 8.4356
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 155.598 3 6.5644
+      vertex 158.232 3 5.73223
+      vertex 157.5 3 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 156.359 3 4.85497
+      vertex 158.232 3 5.73223
+      vertex 155.598 3 6.5644
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 157.75 3 3.60289
+      vertex 158.232 3 5.73223
+      vertex 156.359 3 4.85497
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 160 3 10
+      vertex 159.53 3 11.9753
+      vertex 157.75 3 11.3971
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 159.53 3 11.9753
+      vertex 160 3 10
+      vertex 161.391 3 11.7798
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 158.232 3 9.26777
+      vertex 157.75 3 11.3971
+      vertex 156.359 3 10.145
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 161.768 3 9.26777
+      vertex 161.391 3 11.7798
+      vertex 160 3 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 161.391 3 11.7798
+      vertex 161.768 3 9.26777
+      vertex 163.011 3 10.8442
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 163.011 3 10.8442
+      vertex 161.768 3 9.26777
+      vertex 164.111 3 9.33031
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 162.5 3 7.5
+      vertex 164.111 3 9.33031
+      vertex 161.768 3 9.26777
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 162.5 3 7.5
+      vertex 164.5 3 7.5
+      vertex 164.111 3 9.33031
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 164.111 3 5.66968
+      vertex 162.5 3 7.5
+      vertex 161.768 3 5.73223
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 162.5 3 7.5
+      vertex 164.111 3 5.66968
+      vertex 164.5 3 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 161.391 3 3.22025
+      vertex 161.768 3 5.73223
+      vertex 160 3 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 161.768 3 5.73223
+      vertex 163.011 3 4.15585
+      vertex 164.111 3 5.66968
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 158.232 3 5.73223
+      vertex 157.75 3 3.60289
+      vertex 160 3 5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 159.53 3 3.02465
+      vertex 160 3 5
+      vertex 157.75 3 3.60289
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 161.768 3 5.73223
+      vertex 161.391 3 3.22025
+      vertex 163.011 3 4.15585
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 160 3 5
+      vertex 159.53 3 3.02465
+      vertex 161.391 3 3.22025
+    endloop
+  endfacet
+  facet normal -0.104529 0 0.994522
+    outer loop
+      vertex 159.53 3 3.02465
+      vertex 161.391 0 3.22025
+      vertex 161.391 3 3.22025
+    endloop
+  endfacet
+  facet normal -0.104529 0 0.994522
+    outer loop
+      vertex 161.391 0 3.22025
+      vertex 159.53 3 3.02465
+      vertex 159.53 0 3.02465
+    endloop
+  endfacet
+  facet normal -0.104476 0 -0.994527
+    outer loop
+      vertex 159.53 0 11.9753
+      vertex 161.391 3 11.7798
+      vertex 161.391 0 11.7798
+    endloop
+  endfacet
+  facet normal -0.104476 0 -0.994527
+    outer loop
+      vertex 161.391 3 11.7798
+      vertex 159.53 0 11.9753
+      vertex 159.53 3 11.9753
+    endloop
+  endfacet
+  facet normal 0.30896 0 0.951075
+    outer loop
+      vertex 157.75 3 3.60289
+      vertex 159.53 0 3.02465
+      vertex 159.53 3 3.02465
+    endloop
+  endfacet
+  facet normal 0.30896 0 0.951075
+    outer loop
+      vertex 159.53 0 3.02465
+      vertex 157.75 3 3.60289
+      vertex 157.75 0 3.60289
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 155.598 0 8.4356
+      vertex 155.598 3 6.5644
+      vertex 155.598 3 8.4356
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 155.598 3 6.5644
+      vertex 155.598 0 8.4356
+      vertex 155.598 0 6.5644
+    endloop
+  endfacet
+  facet normal 0.669024 0 -0.743241
+    outer loop
+      vertex 156.359 0 10.145
+      vertex 157.75 3 11.3971
+      vertex 157.75 0 11.3971
+    endloop
+  endfacet
+  facet normal 0.669024 0 -0.743241
+    outer loop
+      vertex 157.75 3 11.3971
+      vertex 156.359 0 10.145
+      vertex 156.359 3 10.145
+    endloop
+  endfacet
+  facet normal 0.308941 0 -0.951081
+    outer loop
+      vertex 157.75 0 11.3971
+      vertex 159.53 3 11.9753
+      vertex 159.53 0 11.9753
+    endloop
+  endfacet
+  facet normal 0.308941 0 -0.951081
+    outer loop
+      vertex 159.53 3 11.9753
+      vertex 157.75 0 11.3971
+      vertex 157.75 3 11.3971
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 180 0 15
+      vertex 180 80 0
+      vertex 180 80 15
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 180 80 0
+      vertex 180 0 15
+      vertex 180 0 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 80 15
+      vertex 180 0 15
+      vertex 180 80 15
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 180 0 15
+      vertex 0 80 15
+      vertex 0 0 15
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 180 80 0
+      vertex 180 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 180 80 0
+      vertex 0 0 0
+      vertex 0 80 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 80 15
+      vertex 0 80 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0 80 15
+      vertex 0 0 0
+      vertex 0 0 15
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
- include wall shelf OpenSCAD source with drywall mounting holes
- ship matching pre-rendered STL and document shelf availability

## Testing
- `pip install -e .`
- `black --check .`
- `codespell docs README.md`
- `pytest -q`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f07785b4832f9978b0a5e512e6b7