### PR TITLE
Ensure CLI writes yearly README summaries

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -19,7 +19,7 @@ jobs:
           coverage report --fail-under=100
       - name: Upload coverage
         if: hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ The `build-stl` workflow runs on every push and pull request targeting `main`
 and attaches the rendered STL files as downloadable artifacts. Navigate to the
 workflow run and download `stl-<year>` to obtain the converted models.
 To avoid bloating the repository, pre-generated baseplate models are no longer stored in the repo. Download the `stl-<year>` artifact or generate them locally.
-Each `stl/<year>` directory includes a generated `README.md` summarizing the baseplate and monthly cube counts.
+Each `stl/<year>` directory includes a generated `README.md` summarizing the baseplate and monthly
+cube counts. The CLI writes these summaries for every year in the requested range, even when a year
+has no contributions, so your shelf layout stays predictable.
 ## Troubleshooting
 
 OpenSCAD exits with status 1 when it cannot access an X display. The

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ Use `--output` to change the `.scad` filename, `--months-per-row` to control the
 grid width, `--stl` to specify an STL output path, and `--colors` to split
 blocks into up to four color groups. By default, the current year's contributions
 are fetched unless `--start-year` and `--end-year` specify a range.
+The CLI always writes yearly summaries in `stl/<year>/README.md` for every year in the
+requested range so folders exist even when a year has zero contributions.
 [`viewer.html`](viewer.html) previews the resulting STLs in the browser with
 [Three.js](https://threejs.org/).
 

--- a/gitshelves/cli.py
+++ b/gitshelves/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from datetime import datetime
 from importlib import metadata
 
-from .fetch import fetch_user_contributions
+from .fetch import fetch_user_contributions, _determine_year_range
 from .scad import (
     generate_scad_monthly,
     generate_scad_monthly_levels,
@@ -72,7 +72,8 @@ def main(argv: list[str] | None = None):
         key = (dt.year, dt.month)
         counts[key] = counts.get(key, 0) + 1
 
-    for year in {y for y, _ in counts}:
+    start_year, end_year = _determine_year_range(args.start_year, args.end_year)
+    for year in range(start_year, end_year + 1):
         write_year_readme(year, counts)
 
     if args.colors == 1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,9 @@ def test_cli_runpy(tmp_path, monkeypatch):
         return [{"created_at": "2021-01-01T00:00:00Z"}]
 
     fetch_mod.fetch_user_contributions = fake_fetch
+    from gitshelves.fetch import _determine_year_range as real_determine_year_range
+
+    fetch_mod._determine_year_range = real_determine_year_range
 
     scad_mod = types.ModuleType("gitshelves.scad")
 
@@ -311,6 +314,80 @@ def test_cli_multiple_colors_without_stl(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert f"Wrote {scad}" in out
     assert captured["groups"] == 2
+
+
+def test_cli_writes_readmes_for_full_range(tmp_path, monkeypatch):
+    base = tmp_path / "out.scad"
+    args = argparse.Namespace(
+        username="user",
+        token=None,
+        start_year=2021,
+        end_year=2023,
+        output=str(base),
+        months_per_row=12,
+        stl=None,
+        colors=1,
+    )
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+
+    def fake_fetch(username, token=None, start_year=None, end_year=None):
+        return [
+            {"created_at": "2021-01-01T00:00:00Z"},
+            {"created_at": "2023-12-31T00:00:00Z"},
+        ]
+
+    monkeypatch.setattr(cli, "fetch_user_contributions", fake_fetch)
+    monkeypatch.setattr(
+        cli, "generate_scad_monthly", lambda counts, months_per_row=12: "SCAD"
+    )
+    monkeypatch.setattr(cli, "scad_to_stl", lambda *a, **k: None)
+
+    called_years: list[int] = []
+
+    def fake_write(year, counts):
+        called_years.append(year)
+        return tmp_path / str(year) / "README.md"
+
+    monkeypatch.setattr(cli, "write_year_readme", fake_write)
+
+    cli.main()
+
+    assert called_years == [2021, 2022, 2023]
+    assert base.read_text() == "SCAD"
+
+
+def test_cli_writes_readme_when_no_contributions(tmp_path, monkeypatch):
+    base = tmp_path / "empty.scad"
+    args = argparse.Namespace(
+        username="user",
+        token=None,
+        start_year=None,
+        end_year=None,
+        output=str(base),
+        months_per_row=12,
+        stl=None,
+        colors=1,
+    )
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(cli, "fetch_user_contributions", lambda *a, **k: [])
+    monkeypatch.setattr(
+        cli, "generate_scad_monthly", lambda counts, months_per_row=12: "SCAD"
+    )
+    monkeypatch.setattr(cli, "scad_to_stl", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "_determine_year_range", lambda start, end: (2042, 2042))
+
+    captured: list[tuple[int, dict]] = []
+
+    def fake_write(year, counts):
+        captured.append((year, dict(counts)))
+        return tmp_path / str(year) / "README.md"
+
+    monkeypatch.setattr(cli, "write_year_readme", fake_write)
+
+    cli.main()
+
+    assert captured == [(2042, {})]
+    assert base.read_text() == "SCAD"
 
 
 def test_cli_version(capsys):


### PR DESCRIPTION
## Summary
- ensure the CLI always generates stl/<year>/README.md for every requested year by reusing the year-range helper
- add regression tests covering empty years and document the behavior in README and docs/index.md

## Testing
- black --check .
- pytest -q
- detect-secrets-hook README.md docs/index.md gitshelves/cli.py tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dcc35adff8832f92ba559344292480