### PR TITLE
✨ : – export binary STLs in scad_to_stl

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and
 git clone https://github.com/kennetek/gridfinity-rebuilt-openscad \
     openscad/lib/gridfinity-rebuilt
 # `scad_to_stl` automatically wraps `openscad` in `xvfb-run` when `$DISPLAY`
-# is unset or empty, matching the CI configuration. Ensure `xvfb-run` is
-# installed on headless systems.
-openscad -o stl/2024/baseplate_2x6.stl openscad/baseplate_2x6.scad
+# is unset or empty and exports binary STLs (`--export-format binstl`) to match
+# the CI configuration. Ensure `xvfb-run` is installed on headless systems.
+openscad -o stl/2024/baseplate_2x6.stl \
+    --export-format binstl openscad/baseplate_2x6.scad
 ```
 
 Run `black --check .`, `pytest -q`, and `codespell docs README.md` before submitting

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,8 @@
 
 For setup and usage details, see the [README](../README.md).
 
-The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes.
+The CLI can export OpenSCAD scripts and, if `openscad` is installed, STL meshes
+using binary output (`--export-format binstl`) to mirror the CI workflow.
 Use `--output` to change the `.scad` filename, `--months-per-row` to control the
 grid width, `--stl` to specify an STL output path, and `--colors` to split
 blocks into up to four color groups. By default, the current year's contributions

--- a/gitshelves/scad.py
+++ b/gitshelves/scad.py
@@ -151,7 +151,8 @@ def scad_to_stl(scad_file: str, stl_file: str) -> None:
 
     If the current environment lacks an X display (``$DISPLAY`` is unset or
     empty), the command is automatically wrapped in ``xvfb-run`` when
-    available. This mirrors the CI configuration and prevents ``openscad`` from
+    available. The STL is exported in binary format (``--export-format
+    binstl``) to mirror the CI configuration and prevent ``openscad`` from
     exiting with code ``1`` on headless servers.
     """
     import os
@@ -161,7 +162,7 @@ def scad_to_stl(scad_file: str, stl_file: str) -> None:
     if shutil.which("openscad") is None:
         raise FileNotFoundError("openscad not found")
 
-    cmd = ["openscad", "-o", stl_file, scad_file]
+    cmd = ["openscad", "-o", stl_file, "--export-format", "binstl", scad_file]
     if not os.environ.get("DISPLAY"):
         if shutil.which("xvfb-run") is None:
             raise RuntimeError("xvfb-run required for headless rendering")

--- a/tests/test_scad.py
+++ b/tests/test_scad.py
@@ -173,7 +173,14 @@ def test_scad_to_stl_calls_openscad(monkeypatch, tmp_path):
     monkeypatch.setattr("subprocess.run", fake_run)
     monkeypatch.setenv("DISPLAY", ":0")
     scad_to_stl(str(scad), str(stl))
-    assert called["cmd"] == ["openscad", "-o", str(stl), str(scad)]
+    assert called["cmd"] == [
+        "openscad",
+        "-o",
+        str(stl),
+        "--export-format",
+        "binstl",
+        str(scad),
+    ]
 
 
 def test_scad_to_stl_uses_xvfb(monkeypatch, tmp_path):
@@ -198,7 +205,17 @@ def test_scad_to_stl_uses_xvfb(monkeypatch, tmp_path):
     monkeypatch.setattr("subprocess.run", fake_run)
 
     scad_to_stl(str(scad), str(stl))
-    assert called["cmd"][0] == "xvfb-run"
+    assert called["cmd"] == [
+        "xvfb-run",
+        "--auto-servernum",
+        "--server-args=-screen 0 1024x768x24",
+        "openscad",
+        "-o",
+        str(stl),
+        "--export-format",
+        "binstl",
+        str(scad),
+    ]
 
 
 def test_scad_to_stl_empty_display(monkeypatch, tmp_path):
@@ -224,6 +241,8 @@ def test_scad_to_stl_empty_display(monkeypatch, tmp_path):
 
     scad_to_stl(str(scad), str(stl))
     assert called["cmd"][0] == "xvfb-run"
+    assert "--export-format" in called["cmd"]
+    assert "binstl" in called["cmd"]
 
 
 def test_scad_to_stl_xvfb_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
what: ensure scad_to_stl calls openscad with --export-format binstl.
why: docs already promise binary STL output; CLI needed to match CI.
how to test: pytest -q; black --check .

------
https://chatgpt.com/codex/tasks/task_e_68dcd68cd040832fb0ba77037210b499