### PR TITLE
Add usage guide for slicer presets and AMS scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ If you fork this repository, replace `futuroptimist` with your GitHub username i
 ```
 
 See [AGENTS.md](AGENTS.md) for agent workflow guidelines and
-[docs](docs/index.md) for additional documentation.
+[docs](docs/index.md) for additional documentation, including a detailed
+[usage guide](docs/usage.md) with slicer presets and AMS filament scripting tips.
 
 ## Dependencies
 

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -168,7 +168,6 @@ This creates an intuitive heat-map effect.
 ## 8  Future Enhancements
 * Auto-query GitHub GraphQL API each month → pre-populate contrib_cube_*.stl counts.
 * Provide a parametric SCAD that arranges cubes on-plate automatically.
-* Add docs/usage.md with slicer presets and AMS filament script examples.
 
 ## 9  Reference Sources
 Base-plate tolerance discussion – Reddit

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,8 @@ using binary output (`--export-format binstl`) to mirror the CI workflow.
 Use `--output` to change the `.scad` filename, `--months-per-row` to control the
 grid width, `--stl` to specify an STL output path, and `--colors` to split
 blocks into up to four color groups. By default, the current year's contributions
-are fetched unless `--start-year` and `--end-year` specify a range.
+are fetched unless `--start-year` and `--end-year` specify a range. For print
+tuning advice, see [usage.md](usage.md).
 The CLI always writes yearly summaries in `stl/<year>/README.md` for every year in the
 requested range so folders exist even when a year has zero contributions.
 Monthly day-level calendars live in `stl/<year>/monthly-5x6/`. Each SCAD arranges up to five days per
@@ -24,6 +25,7 @@ row (with a partial row for 31-day months) so the footprint fits within a 256 mm
 ## Design
 
 - [Gridfinity design specification](gridfinity_design.md) – baseplate and cube dimensions.
+- [Usage guide](usage.md) – slicer presets and AMS filament scripts for the generated models.
 
 ## Spellcheck
 

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -12,5 +12,6 @@ This index lists prompt documents for the Gitshelves repository.
 | [prompts-codex-spellcheck.md](./prompts/codex/prompts-codex-spellcheck.md) | Codex Spellcheck Prompt |
 | [prompts-codex-tests.md](./prompts/codex/prompts-codex-tests.md) | Codex Test Prompt |
 | [repo_feature_summary_prompt.md](./prompts/codex/repo_feature_summary_prompt.md) | Repo Feature Summary Prompt |
+| [usage.md](./usage.md) | Usage Guide |
 
 _Updated manually: 2025-08-21_

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,56 @@
+# Usage Guide
+
+This guide expands on the CLI help in the [README](../README.md) with print-ready defaults for
+Gridfinity-compatible shelves. It highlights slicer settings that keep the contribution cubes crisp
+and includes a sample AMS filament-change script so multi-color prints line up with the exported
+`--colors` outputs.
+
+## Slicer Presets
+
+The presets below assume a 0.4 mm nozzle and PLA/PLA+. Adjust temperatures to match your filament
+manufacturer. Both profiles stay within a 256 mm × 256 mm build volume.
+
+| Part | Layer Height | Perimeters | Infill | Notes |
+|------|--------------|------------|--------|-------|
+| Baseplate 2×6 | 0.2 mm | 4 | 20% gyroid | Enable elephant foot compensation; add 5 mm brim |
+| Contribution cubes | 0.16 mm | 3 | 15% grid | Disable supports; use monotonic top surfaces |
+
+Recommended cooling settings:
+
+- Fan 100% after layer 3 for both parts.
+- Slow external perimeters to 25 mm/s to preserve the Gridfinity lip geometry.
+- Enable "Detect Thin Walls" to avoid skipping the stacking lip detail.
+
+For slicers that support custom G-code on print start, add the following snippet to level the bed and
+log the selected `--colors` count to the printer display:
+
+```gcode
+; Gitshelves base profile
+G28 ; home all axes
+M117 Gitshelves print
+M118 Printing Gitshelves model - colors: [colors]
+```
+
+Replace `[colors]` with the number passed to the CLI so the message matches the generated files.
+
+## AMS Filament Scripts
+
+When using a Bambu Lab AMS (or similar multi-material unit), schedule filament swaps after the base
+plate finishes. The example below assumes two filament changes, producing three color groups (base +
+levels 1-2 + levels 3+).
+
+```gcode
+; Triggered at start of layer 32 (after baseplate is complete)
+M400 ; wait for moves to finish
+M600 A ; swap to Color 2 for levels 1-2
+M118 Swapped to Color 2 for lower levels
+
+; Triggered at start of layer 48
+M400
+M600 B ; swap to Color 3 for high levels
+M118 Swapped to Color 3 for high levels
+```
+
+Pair the change heights with the layer numbers reported by your slicer preview. For four colors,
+insert an additional block before the second swap and update the file list emitted by
+`--colors 4`.

--- a/tests/test_usage_doc.py
+++ b/tests/test_usage_doc.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_usage_doc_includes_required_sections():
+    repo_root = Path(__file__).resolve().parents[1]
+    usage_doc = repo_root / "docs" / "usage.md"
+    assert usage_doc.exists(), "docs/usage.md should exist per design spec"
+    text = usage_doc.read_text(encoding="utf-8")
+    assert "# Usage Guide" in text
+    assert "## Slicer Presets" in text
+    assert "## AMS Filament Scripts" in text
+    assert "```" in text, "usage guide should include at least one example code block"


### PR DESCRIPTION
what: add docs/usage.md and link from docs and README
why: ship documented usage guidance from design spec
how to test: black --check .; pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de04f42464832fb90ae0e7c5ca8dfa