### PR TITLE
Recognize _colorN STL files in the viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Use `--colors` to control multi-color outputs. `--colors 2` produces one block f
 
 Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with
 [Three.js](https://threejs.org/) and experiment with different color counts.
-Use the file picker to load your baseplate and level STLs.
+Use the file picker to load your baseplate and `_colorN` (or legacy `levelN`)
+STLs—the viewer automatically maps these names back to the color groups that the CLI
+generates.
 
 If you fork this repository, replace `futuroptimist` with your GitHub username in badge URLs to keep status badges working.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,8 @@ requested range so folders exist even when a year has zero contributions.
 Monthly day-level calendars live in `stl/<year>/monthly-5x6/`. Each SCAD arranges up to five days per
 row (with a partial row for 31-day months) so the footprint fits within a 256 mm square build area.
 [`viewer.html`](viewer.html) previews the resulting STLs in the browser with
-[Three.js](https://threejs.org/).
+[Three.js](https://threejs.org/). Load the baseplate and `_colorN` (or legacy
+`levelN`) STLs to see each color group rendered with its own material.
 
 ## Prompts
 

--- a/docs/viewer.html
+++ b/docs/viewer.html
@@ -42,7 +42,13 @@ function loadFiles(list) {
   const stls = [];
   for (const file of list) {
     let level = 0;
-    if (/level(\d+)/i.test(file.name)) level = parseInt(RegExp.$1, 10);
+    const colorMatch = file.name.match(/color(\d+)/i);
+    const levelMatch = file.name.match(/level(\d+)/i);
+    if (colorMatch) {
+      level = parseInt(colorMatch[1], 10);
+    } else if (levelMatch) {
+      level = parseInt(levelMatch[1], 10);
+    }
     if (/baseplate/i.test(file.name)) level = 0;
     stls.push({ file, level });
   }

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import re
+
+
+def test_viewer_detects_color_files_for_grouping():
+    """docs/viewer.html should parse `_colorN` filenames for multi-color previews."""
+
+    html = Path("docs/viewer.html").read_text()
+    assert "/color(\\d+)/i" in html, "viewer must recognize _colorN STL names"


### PR DESCRIPTION
## Summary
- teach docs/viewer.html to recognize `_colorN` STL names so color groups render distinctly
- capture the regression with a unit test and refresh README/docs guidance

## Testing
- pip install -e .
- pytest -q
- black --check .

------
https://chatgpt.com/codex/tasks/task_e_68de04f42464832fb90ae0e7c5ca8dfa