### PR TITLE
Add usage guide for slicer presets and AMS scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ python -m gitshelves.cli --version
 
 Use `--colors` to control multi-color outputs. `--colors 2` produces one block file and a baseplate for two-color prints. `--colors 3` or `4` group logarithmic levels into additional color files. Each `*_colorN.scad` (`*_colorN.stl`) contains the blocks for a color group, and the baseplate is written as `<name>_baseplate.scad` (and `.stl` when requested).
 
+For print tuning tips—including slicer presets for baseplates and cubes plus AMS
+automation snippets—see [docs/usage.md](docs/usage.md).
+
 Pass `--gridfinity-layouts` to emit a parametric `stl/<year>/gridfinity_plate.scad` that builds a
 Gridfinity baseplate and arranges monthly contribution cubes on top of it. The layout defaults to six
 columns (a 2×6 plate); adjust the footprint with `--gridfinity-columns` to match your storage grid.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,9 @@ blocks into up to four color groups. `--gridfinity-layouts` writes
 parametric baseplate; adjust the footprint with `--gridfinity-columns`. By
 default, the current year's contributions are fetched unless `--start-year` and
 `--end-year` specify a range.
+
+For printer-specific guidance, see the [usage guide](usage.md) with slicer
+presets and AMS filament scripting examples.
 The CLI always writes yearly summaries in `stl/<year>/README.md` for every year in the
 requested range so folders exist even when a year has zero contributions.
 Monthly day-level calendars live in `stl/<year>/monthly-5x6/`. Each SCAD arranges up to five days per

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -4,6 +4,7 @@ This index lists prompt documents for the Gitshelves repository.
 
 | Document | Title |
 |----------|-------|
+| [usage.md](./usage.md) | Printing & AMS Usage Guide |
 | [automation.md](./prompts/codex/automation.md) | Gitshelves Codex Prompt |
 | [ci-fix.md](./prompts/codex/ci-fix.md) | Codex CI-Failure Fix Prompt |
 | [docs.md](./prompts/codex/docs.md) | Codex Docs Update Prompt |
@@ -13,4 +14,4 @@ This index lists prompt documents for the Gitshelves repository.
 | [tests.md](./prompts/codex/tests.md) | Codex Test Prompt |
 | [repo-feature-summary.md](./prompts/codex/repo-feature-summary.md) | Repo Feature Summary Prompt |
 
-_Updated manually: 2025-08-21_
+_Updated manually: 2025-09-30_

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,71 @@
+# Usage Guide
+
+This guide expands on the README with slicer recommendations and automated
+filament-change scripts so multi-color Gitshelves prints stay reproducible.
+
+## Slicer presets
+
+The contribution charts print as two distinct part families: thin-walled
+baseplates and taller contribution cubes. Start with the presets below and
+adjust for your printer's tolerances.
+
+### Baseplate (2×6 Gridfinity)
+
+- **Material**: PETG or ABS to minimize warp on the long span
+- **Nozzle / layer height**: 0.4 mm nozzle at 0.24 mm layers
+- **Perimeters**: 4 walls to reinforce the magnet lip
+- **Top / bottom**: 5 solid layers; enable ironing for a flat top surface
+- **Infill**: 20% gyroid balances rigidity with print time
+- **Supports**: Off (all geometry is self-supporting)
+- **Bed prep**: Glue stick or textured PEI sheet to avoid corner lift
+
+### Contribution cubes
+
+- **Material**: PLA or PLA+ for crisp edges and easy color swaps
+- **Nozzle / layer height**: 0.4 mm nozzle at 0.20 mm layers
+- **Perimeters**: 2 walls; cubes are solid after color swaps
+- **Top / bottom**: 4 top and bottom layers
+- **Infill**: 15% grid keeps cubes light without sacrificing strength
+- **Supports**: Off
+- **Filament change**: Enable color pause at the desired logarithmic level
+
+## AMS filament scripts
+
+Automated material handling keeps multi-color runs aligned across dozens of
+cubes. The snippets below target common AMS workflows; treat them as templates
+and adapt values to your equipment.
+
+### Bambu Studio (AMS)
+
+Add the following to *Settings → Filament → Filament Change G-code* so the
+toolhead parks safely before the AMS swaps spools:
+
+```gcode
+; Pause for manual inspection before AMS change
+M400                 ; finish buffered moves
+G91                  ; relative positioning
+G1 Z10 F1200         ; lift nozzle 10 mm
+G90                  ; absolute positioning
+G1 X0 Y220 F6000     ; park at the front-left
+M400
+M25                  ; Bambu pause (resumes automatically after swap)
+```
+
+### PrusaSlicer (M600-based pause)
+
+For printers that rely on classic filament-change commands, create a custom
+g-code macro and reference it via a color change marker:
+
+```gcode
+; Trigger filament swap at color transition
+M400                 ; wait for moves to finish
+G91
+G1 Z8 F1200          ; raise nozzle to avoid scars
+G90
+G1 X20 Y200 F6000    ; park near the bed edge
+M400
+M600                 ; prompt operator for new filament
+```
+
+Include this macro under *Printer Settings → Custom G-code → Color Change* so
+PrusaSlicer inserts it whenever you add a color transition marker.

--- a/tests/test_usage_doc.py
+++ b/tests/test_usage_doc.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+def _usage_text() -> str:
+    path = Path("docs/usage.md")
+    assert path.exists(), "docs/usage.md should exist per documentation roadmap"
+    return path.read_text(encoding="utf-8")
+
+
+def test_usage_doc_includes_slicer_presets_section():
+    text = _usage_text().lower()
+    assert "## slicer presets" in text, "Slicer preset guidance should be documented"
+    assert "layer height" in text, "Layer height recommendations must be included"
+    assert "infill" in text, "Infill guidance is expected for slicer presets"
+
+
+def test_usage_doc_includes_ams_filament_script_example():
+    text = _usage_text().lower()
+    assert (
+        "## ams filament scripts" in text
+    ), "AMS automation examples should be present"
+    assert (
+        "g-code" in text or "gcode" in text
+    ), "G-code snippet expected for AMS scripts"
+    assert (
+        "m600" in text or "filament change" in text
+    ), "AMS section should mention filament change handling"


### PR DESCRIPTION
## Summary
- add docs/usage.md with slicer presets and AMS automation guidance
- link the usage guide from existing docs and prompt index
- add regression tests so the promised sections stay documented

## Testing
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df7ee7ece4832f93d75dbfe387cd58