### PR TITLE
✨ : viewer auto-detects block colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL 
 [Three.js](https://threejs.org/) and experiment with different color counts.
 Use the file picker to load your baseplate and `_colorN` (or legacy `levelN`)
 STLs—the viewer automatically maps these names back to the color groups that the CLI
-generates and reports how many color groups it detects from the filenames, so no manual
-dropdown is required.
+generates, shows a detected block-color count next to the picker, and updates the Colors
+dropdown to match the files, so manual selection is optional.
 
 If you fork this repository, replace `futuroptimist` with your GitHub username in badge URLs to keep status badges working.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,9 @@ row (with a partial row for 31-day months) so the footprint fits within a 256 mm
 [`viewer.html`](viewer.html) previews the resulting STLs in the browser with
 [Three.js](https://threejs.org/). Load the baseplate and `_colorN` (or legacy
 `levelN`) STLs to see each color group rendered with its own material. The viewer
-automatically infers how many color groups are present from the filenames and displays the
-detected count alongside the file picker.
+automatically infers how many color groups are present from the filenames,
+displays the detected block-color count next to the picker, and snaps the Colors
+dropdown to the same total for quick confirmation.
 
 ## Prompts
 

--- a/docs/viewer.html
+++ b/docs/viewer.html
@@ -23,9 +23,10 @@
       <option value="5">5</option>
     </select>
   </label>
+  <span id="detectedColors">Detected block colors: 0</span>
 </div>
 <script>
-const palette = [0x1f77b4, 0xff7f0e, 0x2ca02c, 0xd62728];
+const palette = [0x1f77b4, 0xff7f0e, 0x2ca02c, 0xd62728, 0x9467bd];
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
@@ -35,14 +36,25 @@ const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerH
 camera.position.set(120, 120, 120);
 const controls = new THREE.OrbitControls(camera, renderer.domElement);
 const loader = new THREE.STLLoader();
+const colorCount = document.getElementById('colorCount');
+const detectedColors = document.getElementById('detectedColors');
 function clearMeshes() {
   scene.children.filter(o => o.isMesh).forEach(o => scene.remove(o));
 }
 function loadFiles(list) {
   clearMeshes();
-  if (!list.length) return;
+  const files = Array.from(list || []);
+  if (!files.length) {
+    if (detectedColors) {
+      detectedColors.textContent = 'Detected block colors: 0';
+    }
+    if (colorCount) {
+      colorCount.value = '1';
+    }
+    return;
+  }
   const stls = [];
-  for (const file of list) {
+  for (const file of files) {
     let colorIndex = 0;
     const colorMatch = file.name.match(/color(\d+)/i);
     const levelMatch = file.name.match(/level(\d+)/i);
@@ -50,6 +62,26 @@ function loadFiles(list) {
     else if (levelMatch) colorIndex = parseInt(levelMatch[1], 10);
     if (/baseplate/i.test(file.name)) colorIndex = 0;
     stls.push({ file, colorIndex });
+  }
+  const blockColors = new Set(stls.map(item => item.colorIndex).filter(index => index > 0));
+  const baseplateLoaded = stls.some(({ file }) => /baseplate/i.test(file.name));
+  const blockColorCount = blockColors.size;
+  if (detectedColors) {
+    const plural = blockColorCount === 1 ? '' : 's';
+    const baseplateSuffix = baseplateLoaded ? ' + baseplate' : '';
+    detectedColors.textContent = `Detected ${blockColorCount} block color${plural}${baseplateSuffix}`;
+  }
+  if (colorCount && colorCount.options.length) {
+    const totals = Array.from(colorCount.options).map(opt => parseInt(opt.value, 10));
+    const maxColors = Math.max(...totals);
+    let totalGroups = blockColorCount;
+    if (baseplateLoaded) {
+      totalGroups += 1;
+    }
+    if (totalGroups === 0) {
+      totalGroups = 1;
+    }
+    colorCount.value = String(Math.min(totalGroups, maxColors));
   }
   stls.forEach(({ file, colorIndex }) => {
     const reader = new FileReader();

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -8,3 +8,16 @@ def test_viewer_detects_color_files_for_grouping():
     html = Path("docs/viewer.html").read_text()
     assert "/color(\\d+)/i" in html, "viewer must recognize _colorN STL names"
     assert 'value="5"' in html, "viewer should offer a five-color option"
+
+
+def test_viewer_reports_detected_color_groups():
+    """The viewer should surface detected color counts to match README guidance."""
+
+    html = Path("docs/viewer.html").read_text()
+    assert 'id="detectedColors"' in html, "viewer should display detected color summary"
+    assert "detectedColors.textContent" in html
+    assert "colorCount.value =" in html
+    palette = re.search(r"const palette = \[(.*?)\];", html, re.S)
+    assert palette, "palette definition missing"
+    colors = re.findall(r"0x[0-9a-fA-F]+", palette.group(1))
+    assert len(colors) >= 5, "palette should provide baseplate plus four block colors"


### PR DESCRIPTION
what: surface detected block-color count, expand palette, update docs/tests
why: README promised viewer detection and we added regression coverage
how to test: black --check .; pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1b6a602c4832fbcfa42b05931da25