### PR TITLE
docs: align gridfinity spec with shipped usage guide

### DIFF
--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -174,8 +174,11 @@ Colour scheme:
 
 This creates an intuitive heat-map effect.
 
-## 8  Future Enhancements
-* Add docs/usage.md with slicer presets and AMS filament script examples.
+## 8  Usage Guide & AMS automation
+[docs/usage.md](usage.md) now captures the recommended slicer presets and AMS
+filament-change scripts for multi-color prints. Refer contributors there for
+printer tuning details and automation examples instead of treating the guidance
+as future work.
 
 ## 9  Reference Sources
 Base-plate tolerance discussion – Reddit

--- a/tests/test_gridfinity_doc.py
+++ b/tests/test_gridfinity_doc.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_gridfinity_design_notes_usage_guide_is_shipped():
+    """Gridfinity design doc should reflect the shipped usage guide."""
+
+    text = Path("docs/gridfinity_design.md").read_text(encoding="utf-8")
+    assert "docs/usage.md" in text, "Usage guide link should be documented"
+    assert (
+        "Add docs/usage.md" not in text
+    ), "Future enhancements section should not list shipped docs"


### PR DESCRIPTION
## Summary
- add a regression test to ensure the Gridfinity design spec links to the existing usage guide instead of future work
- update docs/gridfinity_design.md to reference docs/usage.md as shipped guidance

## Testing
- black --check .
- pytest -q
- detect-secrets scan $(git diff --cached --name-only)


------
https://chatgpt.com/codex/tasks/task_e_68e31257399c832fa55e0e58cbc25072