### PR TITLE
🧪 : – README dependencies doc coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,14 @@ See [AGENTS.md](AGENTS.md) for agent workflow guidelines and
 
 ## Dependencies
 
- - [Gridfinity-Rebuilt-OpenSCAD](https://github.com/kennetek/gridfinity-rebuilt-openscad) – parametric Gridfinity modules. The CI workflow clones this repo into `openscad/lib/gridfinity-rebuilt` when building STL files.
-- [OpenSCAD](https://openscad.org/) ≥ 2024.06 – required to render STL files.
-- GitHub Actions installs `openscad` with `xvfb` to convert `.scad` sources to binary STL outputs in a headless environment.
-- [vector76/gridfinity_openscad](https://github.com/vector76/gridfinity_openscad) – reference implementation we consult for specification details (MIT).
+- [Gridfinity-Rebuilt-OpenSCAD](https://github.com/kennetek/gridfinity-rebuilt-openscad) –
+  parametric Gridfinity modules. The CI workflow clones this repo into
+  `openscad/lib/gridfinity-rebuilt` when building STL files.
+- [OpenSCAD](https://openscad.org/) ≥ 2024.06 – required to render STL files. Install
+  `xvfb-run` on headless systems; the `scad_to_stl` helper wraps OpenSCAD with it
+  automatically when `$DISPLAY` is missing, mirroring the CI workflow.
+- [vector76/gridfinity_openscad](https://github.com/vector76/gridfinity_openscad) – reference
+  implementation we consult for specification details (MIT).
 
 ## How to Build Locally
 

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -159,7 +159,8 @@ Gridfinity-Rebuilt-OpenSCAD (submodule at openscad/lib/gridfinity-rebuilt) – p
 OpenSCAD ≥ 2024.06 – required for FAST CSG and customizer options
 CI installs OpenSCAD with `apt` and runs the CLI directly
 
-Add a short Dependencies block to the root README.md, linking to each repo.
+The root README's *Dependencies* section now links to these libraries and highlights the
+`xvfb-run` helper for headless renders so documentation stays aligned with automated tests.
 
 ## 7  Printing & Assembly Notes
 PLA/PLA+ recommended for cubes; PETG for long 2×6 base (reduces warp).

--- a/tests/test_gridfinity_doc.py
+++ b/tests/test_gridfinity_doc.py
@@ -9,3 +9,6 @@ def test_gridfinity_design_notes_usage_guide_is_shipped():
     assert (
         "Add docs/usage.md" not in text
     ), "Future enhancements section should not list shipped docs"
+    assert (
+        "Add a short Dependencies block" not in text
+    ), "Dependencies guidance should no longer be flagged as future work"

--- a/tests/test_readme_doc.py
+++ b/tests/test_readme_doc.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_readme_lists_gridfinity_dependencies_and_headless_tools():
+    text = Path("README.md").read_text(encoding="utf-8")
+    assert "## Dependencies" in text, "README should expose a dependencies section"
+    assert (
+        "https://github.com/kennetek/gridfinity-rebuilt-openscad" in text
+    ), "Gridfinity baseplate library must be linked"
+    assert (
+        "https://github.com/vector76/gridfinity_openscad" in text
+    ), "Reference implementation should be credited"
+    assert "xvfb-run" in text, "Headless rendering helper must be documented"


### PR DESCRIPTION
what: add doc tests for README dependencies and headless tooling
why: keep gridfinity design spec aligned with shipped docs
how to test: black --check . && pytest -q
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e3f86fa7d0832f974961400124957e