### PR TITLE
Bundle Gridfinity 1×12 baseplate template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Gitshelves fetches GitHub contribution data and turns it into 3D printable model
 
 A simple wall shelf with drywall mounting holes lives in `openscad/shelf.scad`. Use the pre-rendered `stl/shelf.stl` to print a matching display shelf for your contribution charts.
 
+
+`load_baseplate_scad()` ships both the 2×6 Gridfinity plate and a packaged `baseplate_1x12.scad` for tall single-row layouts, so
+you can source narrow baseplates without cloning the OpenSCAD sources.
+
 ## Usage
 
 1. Install the package in editable mode.

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -13,8 +13,10 @@ We want:
   * **2021 … 2025** sub-folders (five total).  
 * Each folder holds one `baseplate_2x6.stl`, automatically generated from its matching `.scad`.
 
-* **OpenSCAD sources** describing  
+* **OpenSCAD sources** describing
 * A **2 × 6 base plate** (6 columns, 2 rows) that obeys the 42 mm grid and 41.5 mm clearance rules.
+  * A packaged **1 × 12 base plate** lives in `gitshelves.data/baseplate_1x12.scad` so tall single-row layouts are available to
+    downstream scripts without copying the raw OpenSCAD files.
   * A **"contribution cube"** (1 × 1 × 1 U) used to encode the order of magnitude of monthly commits.
 
 * **CI pipeline** (GitHub Actions) that converts every `*.scad` into a binary STL artifact on each

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ bins are stacked onto a parametric baseplate; adjust the footprint with
 default, the current year's contributions are fetched unless `--start-year` and
 `--end-year` specify a range.
 
+`load_baseplate_scad('baseplate_1x12.scad')` provides a bundled single-row Gridfinity plate when you need taller stacks without
+cloning the OpenSCAD templates.
+
 For printer-specific guidance, see the [usage guide](usage.md) with slicer
 presets and AMS filament scripting examples.
 The CLI always writes yearly summaries in `stl/<year>/README.md` for every year in the

--- a/gitshelves/data/baseplate_1x12.scad
+++ b/gitshelves/data/baseplate_1x12.scad
@@ -1,0 +1,28 @@
+// Gridfinity 1×12 baseplate for tall single-row displays
+use <lib/gridfinity-rebuilt/gridfinity-rebuilt-baseplate.scad>;
+
+// Grid unit length (mm) from the Gridfinity specification
+l_grid = 42;
+
+units_x = 12;
+units_y = 1;
+
+// Toggle to drop magnet recesses when weight is low
+include_magnets = true;
+
+gridfinityBaseplate(
+    [units_x, units_y],
+    l_grid,
+    [0, 0],
+    0,
+    bundle_hole_options(
+        refined_hole = false,
+        magnet_hole = include_magnets,
+        screw_hole = false,
+        crush_ribs = true,
+        chamfer = true,
+        supportless = false
+    ),
+    0,
+    [0, 0]
+);

--- a/tests/test_baseplates.py
+++ b/tests/test_baseplates.py
@@ -1,3 +1,4 @@
+import importlib.resources
 from pathlib import Path
 
 from gitshelves.baseplate import load_baseplate_scad
@@ -42,6 +43,18 @@ def test_load_baseplate_scad_prefers_packaged_resource(monkeypatch):
 
     assert load_baseplate_scad() == "// packaged"
     assert captured == {"name": "baseplate_2x6.scad", "encoding": "utf-8"}
+
+
+def test_load_baseplate_scad_loads_packaged_1x12():
+    """The 1×12 template should be bundled for narrow shelves."""
+
+    expected = (
+        importlib.resources.files("gitshelves.data")
+        .joinpath("baseplate_1x12.scad")
+        .read_text(encoding="utf-8")
+    )
+
+    assert load_baseplate_scad("baseplate_1x12.scad") == expected
 
 
 def test_load_baseplate_scad_falls_back_to_repository_checkout(monkeypatch):


### PR DESCRIPTION
## Summary
- bundle the single-row Gridfinity baseplate in package data
- update README and docs to mention the packaged 1×12 plate
- add a regression test covering `load_baseplate_scad("baseplate_1x12.scad")`

## Testing
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e40aba9bf0832f8a2ccbe2a919466b