### PR TITLE
Generate STL files for Gridfinity layouts when requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ For print tuning tips—including slicer presets for baseplates and cubes plus A
 automation snippets—see [docs/usage.md](docs/usage.md).
 
 Pass `--gridfinity-layouts` to emit a parametric `stl/<year>/gridfinity_plate.scad` that builds a
-Gridfinity baseplate and arranges monthly contribution cubes on top of it. The layout defaults to six
-columns (a 2×6 plate); adjust the footprint with `--gridfinity-columns` to match your storage grid.
-Pair it with `--gridfinity-cubes` to generate `contrib_cube_MM.scad` and `.stl` stacks for every
-month that recorded contributions so cube prints are ready without extra modeling work.
+Gridfinity baseplate and arranges monthly contribution cubes on top of it. When `--stl` is also
+provided, matching `gridfinity_plate.stl` files are rendered automatically so layouts are printable
+without extra manual conversion. The layout defaults to six columns (a 2×6 plate); adjust the
+footprint with `--gridfinity-columns` to match your storage grid. Pair it with `--gridfinity-cubes`
+to generate `contrib_cube_MM.scad` and `.stl` stacks for every month that recorded contributions so
+cube prints are ready without extra modeling work.
 
 Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with
 [Three.js](https://threejs.org/) and experiment with different color counts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,11 @@ blocks into up to four color groups (pass `--colors 5` to unlock all four;
 additional orders of magnitude share the fourth color).
 `--gridfinity-layouts` writes `stl/<year>/gridfinity_plate.scad` so Gridfinity
 bins are stacked onto a parametric baseplate; adjust the footprint with
-`--gridfinity-columns`. Enable `--gridfinity-cubes` to export
-`contrib_cube_MM.scad` and `.stl` stacks for every month with activity. By
-default, the current year's contributions are fetched unless `--start-year` and
-`--end-year` specify a range.
+`--gridfinity-columns`. When `--stl` is provided, matching
+`gridfinity_plate.stl` files are rendered automatically. Enable
+`--gridfinity-cubes` to export `contrib_cube_MM.scad` and `.stl` stacks for
+every month with activity. By default, the current year's contributions are
+fetched unless `--start-year` and `--end-year` specify a range.
 
 For printer-specific guidance, see the [usage guide](usage.md) with slicer
 presets and AMS filament scripting examples.

--- a/gitshelves/cli.py
+++ b/gitshelves/cli.py
@@ -121,6 +121,10 @@ def main(argv: list[str] | None = None):
             layout_path = readme_path.parent / "gridfinity_plate.scad"
             layout_path.write_text(layout_text)
             print(f"Wrote {layout_path}")
+            if args.stl:
+                layout_stl_path = layout_path.with_suffix(".stl")
+                scad_to_stl(str(layout_path), str(layout_stl_path))
+                print(f"Wrote {layout_stl_path}")
         if args.gridfinity_cubes:
             year_dir = readme_path.parent
             for month in range(1, 13):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -735,6 +735,66 @@ def test_cli_generates_gridfinity_layout(
     assert f"Wrote {layout_path.relative_to(tmp_path)}" in captured
 
 
+def test_cli_generates_gridfinity_layout_stl(
+    tmp_path, monkeypatch, capsys, gridfinity_library
+):
+    base = tmp_path / "grid.scad"
+    args = argparse.Namespace(
+        username="user",
+        token=None,
+        start_year=2021,
+        end_year=2021,
+        output=str(base),
+        months_per_row=12,
+        stl=str(tmp_path / "grid.stl"),
+        colors=1,
+        gridfinity_layouts=True,
+        gridfinity_columns=3,
+        gridfinity_cubes=False,
+    )
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        cli,
+        "fetch_user_contributions",
+        lambda *a, **k: [{"created_at": "2021-01-01T00:00:00Z"}],
+    )
+    monkeypatch.setattr(
+        cli,
+        "generate_monthly_calendar_scads",
+        lambda daily, year: {m: "//" for m in range(1, 13)},
+    )
+    monkeypatch.setattr(
+        cli, "generate_scad_monthly", lambda counts, months_per_row=12: "SCAD"
+    )
+
+    calls: list[tuple[Path, Path]] = []
+
+    def fake_stl(src: str, dest: str) -> None:
+        calls.append((Path(src), Path(dest)))
+
+    monkeypatch.setattr(cli, "scad_to_stl", fake_stl)
+
+    cli.main()
+
+    layout_path = tmp_path / "stl" / "2021" / "gridfinity_plate.scad"
+    layout_stl = layout_path.with_suffix(".stl")
+
+    resolved_calls = {
+        (src.resolve(strict=False), dest.resolve(strict=False)) for src, dest in calls
+    }
+    expected = (
+        layout_path.resolve(strict=False),
+        layout_stl.resolve(strict=False),
+    )
+    assert expected in resolved_calls
+
+    captured = capsys.readouterr().out
+    rel = layout_stl.relative_to(tmp_path)
+    assert f"Wrote {rel}" in captured
+
+
 def test_cli_generates_gridfinity_cubes(tmp_path, monkeypatch, gridfinity_library):
     base = tmp_path / "grid.scad"
     args = argparse.Namespace(


### PR DESCRIPTION
## Summary
- convert gridfinity_plate.scad into gridfinity_plate.stl whenever --stl is used
- add a regression test covering the new STL export
- document that gridfinity layouts now render STLs automatically

## Testing
- black --check .
- pytest -q
- detect-secrets scan --all-files

------
https://chatgpt.com/codex/tasks/task_e_68e40aba9bf0832f8a2ccbe2a919466b