### PR TITLE
✨ : – Gate Gridfinity cube STLs behind --stl

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Gridfinity baseplate and arranges monthly contribution cubes on top of it. The l
 columns (a 2×6 plate); adjust the footprint with `--gridfinity-columns` to match your storage grid.
 When `--stl` is supplied, the CLI also renders `stl/<year>/gridfinity_plate.stl` so the baseplate is
 ready to print alongside the contribution cubes. Pair it with `--gridfinity-cubes` to generate
-`contrib_cube_MM.scad` and `.stl` stacks for every month that recorded contributions so cube prints are
-ready without extra modeling work.
+`contrib_cube_MM.scad` stacks for every month that recorded contributions, and include `--stl` to render
+matching `.stl` files so cube prints are ready without extra modeling work.
 
 Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with
 [Three.js](https://threejs.org/) and experiment with different color counts.

--- a/docs/gridfinity_design.md
+++ b/docs/gridfinity_design.md
@@ -102,8 +102,8 @@ bin(
 column count (default six) and stack Gridfinity bins for each month on top of
 it. Adjust `--gridfinity-columns` to generate other footprints without editing
 OpenSCAD manually. Pair the flag with `--gridfinity-cubes` to emit
-`contrib_cube_MM.scad`/`.stl` stacks so monthly prints are pre-scaled to each
-month's contribution magnitude.
+`contrib_cube_MM.scad` stacks so monthly prints are pre-scaled to each month's
+contribution magnitude, and add `--stl` to render matching `.stl` files.
 
 ## 5  GitHub Actions Pipeline (.github/workflows/build-stl.yml)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,10 +12,10 @@ additional orders of magnitude share the fourth color).
 bins are stacked onto a parametric baseplate; adjust the footprint with
 `--gridfinity-columns`. When `--stl` is provided, the CLI also renders
 `stl/<year>/gridfinity_plate.stl` so baseplates are printable without manual
-conversion. Enable `--gridfinity-cubes` to export
-`contrib_cube_MM.scad` and `.stl` stacks for every month with activity. By
-default, the current year's contributions are fetched unless `--start-year` and
-`--end-year` specify a range.
+conversion. Enable `--gridfinity-cubes` to export `contrib_cube_MM.scad` stacks
+for every month with activity, and pass `--stl` to render matching `.stl`
+files. By default, the current year's contributions are fetched unless
+`--start-year` and `--end-year` specify a range.
 
 `load_baseplate_scad('baseplate_1x12.scad')` provides a bundled single-row Gridfinity plate when you need taller stacks without
 cloning the OpenSCAD templates.

--- a/gitshelves/cli.py
+++ b/gitshelves/cli.py
@@ -65,7 +65,7 @@ def main(argv: list[str] | None = None):
     parser.add_argument(
         "--gridfinity-cubes",
         action="store_true",
-        help="Generate monthly Gridfinity cube stacks",
+        help="Generate monthly Gridfinity cube stacks (SCAD; add --stl for STLs)",
     )
     try:  # pragma: no cover - metadata lookup
         pkg_version = metadata.version("gitshelves")
@@ -135,9 +135,10 @@ def main(argv: list[str] | None = None):
                 cube_scad_path = year_dir / f"contrib_cube_{month:02d}.scad"
                 cube_scad_path.write_text(cube_scad)
                 print(f"Wrote {cube_scad_path}")
-                cube_stl_path = cube_scad_path.with_suffix(".stl")
-                scad_to_stl(str(cube_scad_path), str(cube_stl_path))
-                print(f"Wrote {cube_stl_path}")
+                if args.stl:
+                    cube_stl_path = cube_scad_path.with_suffix(".stl")
+                    scad_to_stl(str(cube_scad_path), str(cube_stl_path))
+                    print(f"Wrote {cube_stl_path}")
 
     if args.colors == 1:
         scad_text = generate_scad_monthly(counts, months_per_row=args.months_per_row)


### PR DESCRIPTION
what: ensure --gridfinity-cubes only renders cube STLs when --stl is provided
why: docs promise cube meshes require the --stl flag
how to test: pytest -q
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e4c0601fbc832f8a515e469beed3d9