### PR TITLE
Align viewer dropdown with detected block colors

### DIFF
--- a/docs/viewer.html
+++ b/docs/viewer.html
@@ -74,14 +74,8 @@ function loadFiles(list) {
   if (colorCount && colorCount.options.length) {
     const totals = Array.from(colorCount.options).map(opt => parseInt(opt.value, 10));
     const maxColors = Math.max(...totals);
-    let totalGroups = blockColorCount;
-    if (baseplateLoaded) {
-      totalGroups += 1;
-    }
-    if (totalGroups === 0) {
-      totalGroups = 1;
-    }
-    colorCount.value = String(Math.min(totalGroups, maxColors));
+    const selectedColors = Math.max(blockColorCount, 1);
+    colorCount.value = String(Math.min(selectedColors, maxColors));
   }
   stls.forEach(({ file, colorIndex }) => {
     const reader = new FileReader();

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -21,3 +21,15 @@ def test_viewer_reports_detected_color_groups():
     assert palette, "palette definition missing"
     colors = re.findall(r"0x[0-9a-fA-F]+", palette.group(1))
     assert len(colors) >= 5, "palette should provide baseplate plus four block colors"
+
+
+def test_viewer_dropdown_matches_detected_block_colors():
+    """Colors dropdown should follow the detected block-color count (ignoring baseplate)."""
+
+    html = Path("docs/viewer.html").read_text()
+    assert (
+        "Math.max(blockColorCount, 1)" in html
+    ), "viewer should clamp to at least one color"
+    assert (
+        "totalGroups += 1" not in html
+    ), "baseplate should not inflate block-color selection"


### PR DESCRIPTION
what: keep the viewer's Colors select synced to detected block files
why: docs promise the dropdown mirrors block-color groups without baseplate inflation
how to test: pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4c0601fbc832f8a515e469beed3d9