### PR TITLE
Add viewer color dropdown visibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ ready to print alongside the contribution cubes. Pair it with `--gridfinity-cube
 ready without extra modeling work.
 
 Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL files with
-[Three.js](https://threejs.org/) and experiment with different color counts.
-Use the file picker to load your baseplate and `_colorN` (or legacy `levelN`)
-STLs—the viewer automatically maps these names back to the color groups that the CLI
-generates, shows a detected block-color count next to the picker, and updates the Colors
-dropdown to match the files, so manual selection is optional.
+[Three.js](https://threejs.org/) and experiment with different color counts. Use the file
+picker to load your baseplate and `_colorN` (or legacy `levelN`) STLs—the viewer
+automatically maps these names back to the color groups that the CLI generates, shows a
+detected block-color count next to the picker, and updates the Colors dropdown to match the
+files. Adjusting the dropdown now hides higher block-color groups so you can quickly preview
+how the model looks when you print with fewer colors, while still keeping manual selection
+optional.
 
 If you fork this repository, replace `futuroptimist` with your GitHub username in badge URLs to keep status badges working.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,9 @@ positions even when no cubes are rendered.
 `levelN`) STLs to see each color group rendered with its own material. The viewer
 automatically infers how many color groups are present from the filenames,
 displays the detected block-color count next to the picker, and snaps the Colors
-dropdown to the same total for quick confirmation.
+dropdown to the same total for quick confirmation. Lower the value in the
+dropdown to hide higher block-color groups and quickly simulate a print that uses
+fewer colors.
 
 ## Prompts
 

--- a/docs/viewer.html
+++ b/docs/viewer.html
@@ -38,8 +38,25 @@ const controls = new THREE.OrbitControls(camera, renderer.domElement);
 const loader = new THREE.STLLoader();
 const colorCount = document.getElementById('colorCount');
 const detectedColors = document.getElementById('detectedColors');
+const loadedMeshes = [];
+let baseplatePresent = false;
 function clearMeshes() {
   scene.children.filter(o => o.isMesh).forEach(o => scene.remove(o));
+  loadedMeshes.length = 0;
+  baseplatePresent = false;
+}
+function updateMeshVisibility() {
+  const selected = parseInt(colorCount ? colorCount.value : '0', 10);
+  const total = Number.isNaN(selected) ? 0 : selected;
+  const blockThreshold = baseplatePresent ? Math.max(total - 1, 0) : Math.max(total, 0);
+  loadedMeshes.forEach(({ mesh, colorIndex }) => {
+    if (colorIndex === 0) {
+      mesh.visible = baseplatePresent && total > 0;
+    } else {
+      const limit = baseplatePresent ? blockThreshold : Math.max(total, 0);
+      mesh.visible = limit >= colorIndex && limit > 0;
+    }
+  });
 }
 function loadFiles(list) {
   clearMeshes();
@@ -65,6 +82,7 @@ function loadFiles(list) {
   }
   const blockColors = new Set(stls.map(item => item.colorIndex).filter(index => index > 0));
   const baseplateLoaded = stls.some(({ file }) => /baseplate/i.test(file.name));
+  baseplatePresent = baseplateLoaded;
   const blockColorCount = blockColors.size;
   if (detectedColors) {
     const plural = blockColorCount === 1 ? '' : 's';
@@ -83,6 +101,7 @@ function loadFiles(list) {
     }
     colorCount.value = String(Math.min(totalGroups, maxColors));
   }
+  updateMeshVisibility();
   stls.forEach(({ file, colorIndex }) => {
     const reader = new FileReader();
     reader.onload = e => {
@@ -94,11 +113,16 @@ function loadFiles(list) {
       const mesh = new THREE.Mesh(geo, mat);
       mesh.name = file.name;
       scene.add(mesh);
+      loadedMeshes.push({ mesh, colorIndex });
+      updateMeshVisibility();
     };
     reader.readAsArrayBuffer(file);
   });
 }
 document.getElementById('files').addEventListener('change', e => loadFiles(e.target.files));
+if (colorCount) {
+  colorCount.addEventListener('change', updateMeshVisibility);
+}
 const light = new THREE.DirectionalLight(0xffffff, 1);
 light.position.set(1, 1, 1).normalize();
 scene.add(light);

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -21,3 +21,12 @@ def test_viewer_reports_detected_color_groups():
     assert palette, "palette definition missing"
     colors = re.findall(r"0x[0-9a-fA-F]+", palette.group(1))
     assert len(colors) >= 5, "palette should provide baseplate plus four block colors"
+
+
+def test_viewer_dropdown_toggles_mesh_visibility():
+    """Colors dropdown should change mesh visibility for quick previews."""
+
+    html = Path("docs/viewer.html").read_text()
+    assert "const loadedMeshes" in html
+    assert "colorCount.addEventListener('change'" in html
+    assert "mesh.visible" in html


### PR DESCRIPTION
## Summary
- enable the viewer Colors dropdown to hide higher block-color groups
- add a regression test and document the new interaction in README and docs

## Testing
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4c0601fbc832f8a515e469beed3d9