### PR TITLE
✨ Align viewer color dropdown with detected files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Open [docs/viewer.html](docs/viewer.html) in a browser to preview generated STL 
 [Three.js](https://threejs.org/) and experiment with different color counts.
 Use the file picker to load your baseplate and `_colorN` (or legacy `levelN`)
 STLs—the viewer automatically maps these names back to the color groups that the CLI
-generates, shows a detected block-color count next to the picker, and updates the Colors
-dropdown to match the files, so manual selection is optional.
+generates, shows a detected block-color count next to the picker, and rebuilds the Colors
+dropdown so it shrinks or expands to the detected files, making manual selection optional.
 
 If you fork this repository, replace `futuroptimist` with your GitHub username in badge URLs to keep status badges working.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,8 @@ positions even when no cubes are rendered.
 [Three.js](https://threejs.org/). Load the baseplate and `_colorN` (or legacy
 `levelN`) STLs to see each color group rendered with its own material. The viewer
 automatically infers how many color groups are present from the filenames,
-displays the detected block-color count next to the picker, and snaps the Colors
-dropdown to the same total for quick confirmation.
+displays the detected block-color count next to the picker, and rebuilds the Colors
+dropdown so it shrinks or expands to the detected total for quick confirmation.
 
 ## Prompts
 

--- a/docs/viewer.html
+++ b/docs/viewer.html
@@ -49,6 +49,7 @@ function loadFiles(list) {
       detectedColors.textContent = 'Detected block colors: 0';
     }
     if (colorCount) {
+      colorCount.innerHTML = '<option value="1">1</option>';
       colorCount.value = '1';
     }
     return;
@@ -71,11 +72,20 @@ function loadFiles(list) {
     const baseplateSuffix = baseplateLoaded ? ' + baseplate' : '';
     detectedColors.textContent = `Detected ${blockColorCount} block color${plural}${baseplateSuffix}`;
   }
-  if (colorCount && colorCount.options.length) {
-    const totals = Array.from(colorCount.options).map(opt => parseInt(opt.value, 10));
-    const maxColors = Math.max(...totals);
-    const selectedColors = Math.max(blockColorCount, 1);
-    colorCount.value = String(Math.min(selectedColors, maxColors));
+  if (colorCount) {
+    const detected = Math.max(blockColorCount, 1);
+    const values = Array.from({ length: detected }, (_, idx) => String(idx + 1));
+    const existing = Array.from(colorCount.options).map(opt => opt.value);
+    const differs =
+      existing.length !== values.length ||
+      existing.some((value, idx) => value !== values[idx]);
+    if (differs) {
+      colorCount.innerHTML = values
+        .map(value => `<option value="${value}">${value}</option>`)
+        .join('');
+    }
+    const index = blockColorCount > 0 ? blockColorCount - 1 : 0;
+    colorCount.value = values[index] ?? values[0];
   }
   stls.forEach(({ file, colorIndex }) => {
     const reader = new FileReader();

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -33,3 +33,9 @@ def test_viewer_dropdown_matches_detected_block_colors():
     assert (
         "totalGroups += 1" not in html
     ), "baseplate should not inflate block-color selection"
+    assert (
+        "colorCount.innerHTML" in html
+    ), "viewer should rebuild dropdown options to match detected colors"
+    assert (
+        "Array.from({ length: detected }" in html
+    ), "viewer should derive option values from detected color count"


### PR DESCRIPTION
## Summary
- rebuild docs viewer color dropdown so it tracks detected block colors
- document the dynamic dropdown behavior in README and docs index
- extend viewer tests to cover the regenerated color selector

## Testing
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e55c3e4938832fb366944f2d0d1951