### PR TITLE
Clean up stale Gridfinity cube metadata

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,8 +74,8 @@ automatically whenever this flag is enabled—even without `--stl`—so install
 `openscad` on systems that generate cube stacks. Months that no longer
 record activity remove any existing `contrib_cube_MM` exports so only active
 months keep cube stacks on disk. Runs that omit `--gridfinity-cubes` also clear
-those cube files so directories always reflect the latest activity
-snapshot. By default, the current year's contributions are fetched unless
+those cube files and their metadata so directories always reflect the latest
+activity snapshot. By default, the current year's contributions are fetched unless
 `--start-year` and `--end-year` specify a range. Months that no longer have
 contributions remove their old `contrib_cube_MM` files (and any lingering STLs
 when cube meshes are not requested elsewhere) so directories stay in sync with the

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,9 @@ activity snapshot. By default, the current year's contributions are fetched unle
 `--start-year` and `--end-year` specify a range. Months that no longer have
 contributions remove their old `contrib_cube_MM` files (and any lingering STLs
 when cube meshes are not requested elsewhere) so directories stay in sync with the
-latest activity snapshot.
+latest activity snapshot. Clearing cube STLs does not affect metadata for active
+months, so SCAD files continue to ship with the metadata that describes them even
+when meshes are intentionally removed.
 Color-specific outputs also repeat the zero-contribution annotations so each
 file documents the full monthly layout even when opened in isolation.
 Whether no month produces any blocks or only some of the requested color groups

--- a/gitshelves/cli/__init__.py
+++ b/gitshelves/cli/__init__.py
@@ -173,6 +173,13 @@ def _cleanup_gridfinity_cube_outputs(
         if remove_stls or month not in active_months:
             stl_path.unlink(missing_ok=True)
 
+    for metadata_path in year_dir.glob("contrib_cube_*.json"):
+        month = _cube_month_from_path(metadata_path)
+        if month is None:
+            continue
+        if remove_stls or month not in active_months:
+            metadata_path.unlink(missing_ok=True)
+
 
 def _cleanup_color_outputs(
     base_output: Path,

--- a/gitshelves/cli/__init__.py
+++ b/gitshelves/cli/__init__.py
@@ -177,7 +177,7 @@ def _cleanup_gridfinity_cube_outputs(
         month = _cube_month_from_path(metadata_path)
         if month is None:
             continue
-        if remove_stls or month not in active_months:
+        if month not in active_months:
             metadata_path.unlink(missing_ok=True)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3334,11 +3334,14 @@ def test_cleanup_gridfinity_cube_outputs_removes_orphan_metadata(tmp_path):
     stale_metadata.write_text("{}")
     keep_metadata = tmp_path / "contrib_cube_02.json"
     keep_metadata.write_text("{}")
+    ignored_metadata = tmp_path / "contrib_cube_00.json"
+    ignored_metadata.write_text("{}")
 
     cli._cleanup_gridfinity_cube_outputs(tmp_path, {2}, remove_stls=False)
 
     assert not stale_metadata.exists()
     assert keep_metadata.exists()
+    assert ignored_metadata.exists(), "Non-month filenames should be preserved"
 
 
 def test_cleanup_gridfinity_cube_outputs_keeps_active_metadata_with_remove_stls(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3327,6 +3327,20 @@ def test_cleanup_gridfinity_cube_outputs(tmp_path):
     assert not keep_stl.exists()
 
 
+def test_cleanup_gridfinity_cube_outputs_removes_orphan_metadata(tmp_path):
+    """Stale Gridfinity metadata should be removed even when SCADs are missing."""
+
+    stale_metadata = tmp_path / "contrib_cube_01.json"
+    stale_metadata.write_text("{}")
+    keep_metadata = tmp_path / "contrib_cube_02.json"
+    keep_metadata.write_text("{}")
+
+    cli._cleanup_gridfinity_cube_outputs(tmp_path, {2}, remove_stls=False)
+
+    assert not stale_metadata.exists()
+    assert keep_metadata.exists()
+
+
 def test_cli_gridfinity_cubes_remove_stale_files(
     tmp_path, monkeypatch, gridfinity_library
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3341,6 +3341,25 @@ def test_cleanup_gridfinity_cube_outputs_removes_orphan_metadata(tmp_path):
     assert keep_metadata.exists()
 
 
+def test_cleanup_gridfinity_cube_outputs_keeps_active_metadata_with_remove_stls(
+    tmp_path,
+):
+    """Active-month metadata should remain even when STLs are purged."""
+
+    keep_scad = tmp_path / "contrib_cube_02.scad"
+    keep_scad.write_text("cube();")
+    keep_metadata = tmp_path / "contrib_cube_02.json"
+    keep_metadata.write_text("{}")
+    stale_metadata = tmp_path / "contrib_cube_03.json"
+    stale_metadata.write_text("{}")
+
+    cli._cleanup_gridfinity_cube_outputs(tmp_path, {2}, remove_stls=True)
+
+    assert keep_scad.exists(), "Active SCAD should be preserved"
+    assert keep_metadata.exists(), "Active metadata should be preserved"
+    assert not stale_metadata.exists(), "Inactive metadata should be removed"
+
+
 def test_cli_gridfinity_cubes_remove_stale_files(
     tmp_path, monkeypatch, gridfinity_library
 ):


### PR DESCRIPTION
## Summary
- remove orphaned Gridfinity cube metadata when cleaning up stale Gridfinity cube outputs
- document that cube cleanup also clears matching metadata
- add regression coverage for orphaned cube metadata files

## Testing
- black --check .
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69212e74e224832fb093585620414f8d)